### PR TITLE
Add regex attribute names to map keys.

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -335,8 +335,8 @@ Attribute.prototype.toDynamo = function(val, noSet, model) {
     for(var name in this.attributes) {
       var attr = this.attributes[name];
       attr.setDefault(model);
-      if (this.nameRegex) {
-        var regex = this.nameRegex;
+      if (attr.nameRegex) {
+        var regex = attr.nameRegex;
         for(var propName in val) {
           if (regex.test(propName)) {
             dynamoAttr = attr.toDynamo(val[propName], undefined, model);
@@ -431,7 +431,7 @@ Attribute.prototype.parseDynamo = function(json) {
         var childAttr = attr.attributes[attrName];
         if (childAttr.nameRegex) {
           var regex = childAttr.nameRegex;
-          for (propName in v) {
+          for (var propName in v) {
             if (regex.test(propName)) {
               attrVal = childAttr.parseDynamo(v[propName]);
               if(attrVal !== undefined && attrVal !== null){

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -18,7 +18,7 @@ function Attribute(schema, name, value) {
   this.name = name;
 
   // If name begins/ends with a slash it is a regex used to match properties in a 'map'
-  if (name && name.substr(0, 1) === "/" && name.substr(name.length - 1, 1) === "/") {
+  if (name && name.substr(0, 1) === '/' && name.substr(name.length - 1, 1) === '/') {
     this.nameRegex = new RegExp(name.substr(1, name.length - 2));
   }
 

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -283,11 +283,13 @@ Attribute.prototype.findAttribute = function(path) {
   }
 
   var period = path.indexOf('.');
-  if (period < 0)
+  if (period < 0) {
     period = path.length;
+  }
   var bracket = path.indexOf('[');
-  if (bracket < 0 || bracket > period)
+  if (bracket < 0 || bracket > period) {
     bracket = period;
+  }
   var pos = period < bracket ? period : bracket;
 
   var attrName = path.substring(0, pos);
@@ -298,7 +300,7 @@ Attribute.prototype.findAttribute = function(path) {
   if (this.type.name === 'map') {
     attr = this.attributes[attrName];
     // no normal match - check if it matches a regex
-    if (attr == undefined)
+    if (attr === undefined)
     {
       for (var subAttrName in this.attributes) {
         var subAttr = this.attributes[subAttrName];
@@ -308,7 +310,7 @@ Attribute.prototype.findAttribute = function(path) {
         }
       }
     }
-  } else if (this.type.name == 'list') {
+  } else if (this.type.name === 'list') {
     // schema of sub item in list is always at 0
     attr = this.attributes[0];
   } 
@@ -319,7 +321,7 @@ Attribute.prototype.findAttribute = function(path) {
   }
 
   return attr;
-}
+};
 
 Attribute.prototype.toDynamo = function(val, noSet, model) {
 

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -17,6 +17,11 @@ function Attribute(schema, name, value) {
 
   this.name = name;
 
+  // If name begins/ends with a slash it is a regex used to match properties in a 'map'
+  if (name.substr(0, 1) === "/" && name.substr(name.length - 1, 1) === "/") {
+    this.nameRegex = new RegExp(name.substr(1, name.length - 2));
+  }
+
   this.setType(value);
 
   if(!schema.useDocumentTypes) {
@@ -326,13 +331,25 @@ Attribute.prototype.toDynamo = function(val, noSet, model) {
     }.bind(this));
   } else if (type.name === 'map') {
 
-    var dynamoMapObj = {};
+    var dynamoMapObj = {}, dynamoAttr = null;
     for(var name in this.attributes) {
       var attr = this.attributes[name];
       attr.setDefault(model);
-      var dynamoAttr = attr.toDynamo(val[name], undefined, model);
-      if(dynamoAttr) {
-        dynamoMapObj[attr.name] = dynamoAttr;
+      if (this.nameRegex) {
+        var regex = this.nameRegex;
+        for(var propName in val) {
+          if (regex.test(propName)) {
+            dynamoAttr = attr.toDynamo(val[propName], undefined, model);
+            if(dynamoAttr) {
+              dynamoMapObj[propName] = dynamoAttr;
+            }            
+          }
+        }
+      } else {
+        dynamoAttr = attr.toDynamo(val[name], undefined, model);
+        if(dynamoAttr) {
+          dynamoMapObj[attr.name] = dynamoAttr;
+        }
       }
     }
     dynamoObj.M = dynamoMapObj;
@@ -408,12 +425,25 @@ Attribute.prototype.parseDynamo = function(json) {
 
   function mapify(v, attr){
     if(!v){ return; }
-    var val = {};
+    var val = {}, attrVal = null;
 
     for(var attrName in attr.attributes) {
-        var attrVal = attr.attributes[attrName].parseDynamo(v[attrName]);
-        if(attrVal !== undefined && attrVal !== null){
-          val[attrName] = attrVal;
+        var childAttr = ttr.attributes[attrName];
+        if (childAttr.nameRegex) {
+          var regex = childAttr.nameRegex;
+          for (propName in v) {
+            if (regex.test(propName)) {
+              attrVal = childAttr.parseDynamo(v[propName]);
+              if(attrVal !== undefined && attrVal !== null){
+                val[propName] = attrVal;
+              }
+            }
+          }
+        } else {
+          attrVal = childAttr.parseDynamo(v[attrName]);
+          if(attrVal !== undefined && attrVal !== null){
+            val[attrName] = attrVal;
+          }
         }
       }
     return val;

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -276,6 +276,51 @@ Attribute.prototype.setDefault = function(model) {
   }
 };
 
+Attribute.prototype.findAttribute = function(path) {
+
+  if (this.type.name !== 'map' && this.type.name !== 'list') {
+    return null;
+  }
+
+  var period = path.indexOf('.');
+  if (period < 0)
+    period = path.length;
+  var bracket = path.indexOf('[');
+  if (bracket < 0 || bracket > period)
+    bracket = period;
+  var pos = period < bracket ? period : bracket;
+
+  var attrName = path.substring(0, pos);
+  var pathLeft = path.substring(period + 1);
+
+  var attr = null;
+
+  if (this.type.name === 'map') {
+    attr = this.attributes[attrName];
+    // no normal match - check if it matches a regex
+    if (attr == undefined)
+    {
+      for (var subAttrName in this.attributes) {
+        var subAttr = this.attributes[subAttrName];
+        if (subAttr.nameRegex && subAttr.nameRegex.test(attrName)) {
+          attr = subAttr;
+          break;
+        }
+      }
+    }
+  } else if (this.type.name == 'list') {
+    // schema of sub item in list is always at 0
+    attr = this.attributes[0];
+  } 
+
+  // recursively find remainder of path
+  if (attr && pathLeft.length > 0) {
+    attr = attr.findAttribute(pathLeft);
+  }
+
+  return attr;
+}
+
 Attribute.prototype.toDynamo = function(val, noSet, model) {
 
   if(val === null || val === undefined || val === '') {

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -428,7 +428,7 @@ Attribute.prototype.parseDynamo = function(json) {
     var val = {}, attrVal = null;
 
     for(var attrName in attr.attributes) {
-        var childAttr = ttr.attributes[attrName];
+        var childAttr = attr.attributes[attrName];
         if (childAttr.nameRegex) {
           var regex = childAttr.nameRegex;
           for (propName in v) {

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -18,7 +18,7 @@ function Attribute(schema, name, value) {
   this.name = name;
 
   // If name begins/ends with a slash it is a regex used to match properties in a 'map'
-  if (name.substr(0, 1) === "/" && name.substr(name.length - 1, 1) === "/") {
+  if (name && name.substr(0, 1) === "/" && name.substr(name.length - 1, 1) === "/") {
     this.nameRegex = new RegExp(name.substr(1, name.length - 2));
   }
 

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -394,7 +394,7 @@ Model.update = function(NewModel, key, update, options, next) {
       updatePUT = update.$PUT;
     }
     for(var putItem in updatePUT) {
-      var putAttr = schema.attributes[putItem];
+      var putAttr = schema.findAttribute(putItem);
       if(putAttr) {
         var val = updatePUT[putItem];
         if(val === null || val === undefined || val === '' || (Array.isArray(val) && val.length === 0)) {
@@ -408,7 +408,7 @@ Model.update = function(NewModel, key, update, options, next) {
 
   if(update.$DELETE) {
     for(var deleteItem in update.$DELETE) {
-      var deleteAttr = schema.attributes[deleteItem];
+      var deleteAttr = schema.findAttribute(deleteItem);
       if(deleteAttr) {
         var delVal = update.$DELETE[deleteItem];
         if(delVal !== null && delVal !== undefined) {
@@ -422,7 +422,7 @@ Model.update = function(NewModel, key, update, options, next) {
 
   if(update.$ADD) {
     for(var addItem in update.$ADD) {
-      var addAttr = schema.attributes[addItem];
+      var addAttr = schema.findAttribute(addItem);
       if(addAttr) {
         operations.ADD[addItem] = addAttr.toDynamo(update.$ADD[addItem]);
       }
@@ -450,10 +450,22 @@ Model.update = function(NewModel, key, update, options, next) {
         } else {
           updateReq.UpdateExpression += ',';
         }
+
+        var period = k.indexOf('.');
+        if (period < 0)
+          period = k.length;
+        var bracket = k.indexOf('[');
+        if (bracket < 0 || bracket > period)
+          bracket = period;
+        var pos = period < bracket ? period : bracket;
+        
+        var attrKey = k.substring(0, pos);
+        var attrSuffix = k.substring(pos);
+
         var attrName = '#_n' + attrCount;
         var valName = ':_p' + attrCount;
-        updateReq.UpdateExpression += attrName;
-        updateReq.ExpressionAttributeNames[attrName] = k;
+        updateReq.UpdateExpression += attrName + attrSuffix;
+        updateReq.ExpressionAttributeNames[attrName] = attrKey;
         if(operations[op][k]) {
           updateReq.UpdateExpression += ' ' + (op === 'SET' ? '= ' : '') + valName;
           updateReq.ExpressionAttributeValues[valName] = operations[op][k];

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -452,11 +452,13 @@ Model.update = function(NewModel, key, update, options, next) {
         }
 
         var period = k.indexOf('.');
-        if (period < 0)
+        if (period < 0) {
           period = k.length;
+        }
         var bracket = k.indexOf('[');
-        if (bracket < 0 || bracket > period)
+        if (bracket < 0 || bracket > period) {
           bracket = period;
+        }
         var pos = period < bracket ? period : bracket;
         
         var attrKey = k.substring(0, pos);

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -57,9 +57,6 @@ Model.compile = function compile (name, schema, options, base) {
   function NewModel (obj) {
     Model.call(this, obj);
     applyVirtuals(this, schema);
-    if (options.hookModel) {
-      options.hookModel(this);
-    }
   }
 
   util.inherits(NewModel, Model);
@@ -137,10 +134,6 @@ Model.compile = function compile (name, schema, options, base) {
       throw err;
     }
   });
-
-  if (options.hookModel) {
-    options.hookModel(NewModel);
-  }
 
   return NewModel;
 };

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -71,6 +71,10 @@ Model.compile = function compile (name, schema, options, base) {
   };
   NewModel.$__ = NewModel.prototype.$__;
 
+  // make copy of table/schema available top level to make helpers functions easier to create
+  NewModel.table = table;
+  NewModel.schema = schema;
+
   NewModel.get = function (key, options, next) {
     return Model.get(NewModel, key, options, next);
   };

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -330,6 +330,31 @@ Model.get = function(NewModel, key, options, next) {
   return deferred.promise.nodeify(next);
 };
 
+function parseAttrPath(path) {
+
+  var period = path.indexOf('.');
+  if (period < 0) {
+    period = path.length;
+  }
+  var begBracket = path.indexOf('[');
+  if (begBracket < 0 || begBracket > period) {
+    begBracket = period;
+  }
+  var endBracket = path.indexOf(']');
+  if (endBracket < 0 || endBracket > period) {
+    endBracket = period - 1;
+  }
+  
+  var name = path.substring(0, begBracket);
+  var indexer = path.substring(begBracket, endBracket + 1);
+  var path = path.substring(period + 1);
+
+  var token = { name: name, indexer: indexer, path: path };
+  // debug("partAttrPath: " + util.inspect(token));
+  
+  return token;
+}
+
 /* NewModel.update({id: 123},
 // {
 //   $PUT: {a: 1, b: 2},
@@ -451,28 +476,24 @@ Model.update = function(NewModel, key, update, options, next) {
           updateReq.UpdateExpression += ',';
         }
 
-        var period = k.indexOf('.');
-        if (period < 0) {
-          period = k.length;
-        }
-        var bracket = k.indexOf('[');
-        if (bracket < 0 || bracket > period) {
-          bracket = period;
-        }
-        var pos = period < bracket ? period : bracket;
-        
-        var attrKey = k.substring(0, pos);
-        var attrSuffix = k.substring(pos);
-
+        // parse path to replace attr indentifiers with name vars - preserve indexers
+        var token = { path: k };
+        var firstToken = true;
+        while (token.path.length > 0) {
+          token = parseAttrPath(token.path);
         var attrName = '#_n' + attrCount;
+          attrCount += 1;
+          updateReq.UpdateExpression += (firstToken ? "" : ".") + attrName + token.indexer;
+          updateReq.ExpressionAttributeNames[attrName] = token.name;
+          firstToken = false;
+        } while (token.path.length > 0);
+
+        // add update op to list
         var valName = ':_p' + attrCount;
-        updateReq.UpdateExpression += attrName + attrSuffix;
-        updateReq.ExpressionAttributeNames[attrName] = attrKey;
         if(operations[op][k]) {
           updateReq.UpdateExpression += ' ' + (op === 'SET' ? '= ' : '') + valName;
           updateReq.ExpressionAttributeValues[valName] = operations[op][k];
         }
-        attrCount += 1;
       }
     }
   }

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -378,7 +378,7 @@ Model.update = function(NewModel, key, update, options, next) {
     Key: {},
     ExpressionAttributeNames: {},
     ExpressionAttributeValues: {},
-    ReturnValues: 'ALL_NEW'
+    ReturnValues: options.returnValues || 'ALL_NEW'
   };
   processCondition(updateReq, options, NewModel.$__.schema);
 

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -347,9 +347,9 @@ function parseAttrPath(path) {
   
   var name = path.substring(0, begBracket);
   var indexer = path.substring(begBracket, endBracket + 1);
-  var path = path.substring(period + 1);
+  var nextPath = path.substring(period + 1);
 
-  var token = { name: name, indexer: indexer, path: path };
+  var token = { name: name, indexer: indexer, path: nextPath };
   // debug("partAttrPath: " + util.inspect(token));
   
   return token;

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -411,6 +411,7 @@ Model.update = function(NewModel, key, update, options, next) {
   var operations = {
     SET: {},
     ADD: {},
+    DELETE: {},
     REMOVE: {}
   };
   if(update.$PUT || (!update.$PUT && !update.$DELETE && !update.$ADD)) {
@@ -436,10 +437,18 @@ Model.update = function(NewModel, key, update, options, next) {
       var deleteAttr = schema.findAttribute(deleteItem);
       if(deleteAttr) {
         var delVal = update.$DELETE[deleteItem];
-        if(delVal !== null && delVal !== undefined) {
-          operations.REMOVE[deleteItem] = deleteAttr.toDynamo(delVal);
+        if (deleteAttr.isSet) {
+          if(delVal !== null && delVal !== undefined) {
+            operations.DELETE[deleteItem] = deleteAttr.toDynamo(delVal);
+          } else {
+            operations.DELETE[deleteItem] = null;
+          }
         } else {
-          operations.REMOVE[deleteItem] = null;
+          if(delVal !== null && delVal !== undefined) {
+            operations.REMOVE[deleteItem] = deleteAttr.toDynamo(delVal);
+          } else {
+            operations.REMOVE[deleteItem] = null;
+          }
         }
       }
     }

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -57,6 +57,9 @@ Model.compile = function compile (name, schema, options, base) {
   function NewModel (obj) {
     Model.call(this, obj);
     applyVirtuals(this, schema);
+    if (options.hookModel) {
+      options.hookModel(this);
+    }
   }
 
   util.inherits(NewModel, Model);
@@ -134,6 +137,10 @@ Model.compile = function compile (name, schema, options, base) {
       throw err;
     }
   });
+
+  if (options.hookModel) {
+    hookModel(NewModel);
+  }
 
   return NewModel;
 };

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -139,7 +139,7 @@ Model.compile = function compile (name, schema, options, base) {
   });
 
   if (options.hookModel) {
-    hookModel(NewModel);
+    options.hookModel(NewModel);
   }
 
   return NewModel;

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -213,7 +213,7 @@ Query.prototype.exec = function (next) {
       }
 
 
-      var models = data.Items.map(toModel);
+      var models = (data.Items || []).map(toModel);
 
       if(options.one) {
         if (!models || models.length === 0) {

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -183,6 +183,9 @@ Query.prototype.exec = function (next) {
     queryReq.ExclusiveStartKey = options.ExclusiveStartKey;
   }
 
+  if (options.Select) {
+    queryReq.Select = options.Select;
+  }
 
   function query () {
     var deferred = Q.defer();
@@ -220,6 +223,8 @@ Query.prototype.exec = function (next) {
       }
 
       models.lastKey = data.LastEvaluatedKey;
+      models.count = data.Count;
+
       deferred.resolve(models);
     });
 
@@ -434,6 +439,10 @@ Query.prototype.attributes = function (attributes) {
   return this;
 };
 
+Query.prototype.select = function (val) {
+  this.options.Select = val;
+  return this;
+};
 
 
 module.exports = Query;

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -57,6 +57,29 @@ function Schema(obj, options) {
 
 };*/
 
+
+Schema.prototype.findAttribute = function(path) {
+
+  var period = path.indexOf('.');
+  if (period < 0)
+    period = path.length;
+  var bracket = path.indexOf('[');
+  if (bracket < 0 || bracket > period)
+    bracket = period;
+  var pos = period < bracket ? period : bracket;
+
+  var attrName = path.substring(0, pos);
+  var pathLeft = path.substring(period + 1);
+
+  var attr = this.attributes[attrName];
+
+  if (attr && pathLeft.length > 0) {
+    attr = attr.findAttribute(pathLeft);
+  }
+
+  return attr;
+}
+
 Schema.prototype.toDynamo = function(model) {
 
   var dynamoObj = {};

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -61,11 +61,13 @@ function Schema(obj, options) {
 Schema.prototype.findAttribute = function(path) {
 
   var period = path.indexOf('.');
-  if (period < 0)
+  if (period < 0) {
     period = path.length;
+  }
   var bracket = path.indexOf('[');
-  if (bracket < 0 || bracket > period)
+  if (bracket < 0 || bracket > period) {
     bracket = period;
+  }
   var pos = period < bracket ? period : bracket;
 
   var attrName = path.substring(0, pos);
@@ -78,7 +80,7 @@ Schema.prototype.findAttribute = function(path) {
   }
 
   return attr;
-}
+};
 
 Schema.prototype.toDynamo = function(model) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,19 +81,11 @@ Dynamoose.prototype.setDefaults = function (options) {
 };
 
 Dynamoose.prototype.use = function (usefn) {
-  middleware.push(usefn);
+  usefn(module.exports);
 }
 
 Dynamoose.prototype.Schema = Schema;
 Dynamoose.prototype.Table = require('./Table');
 Dynamoose.prototype.Dynamoose = Dynamoose;
 
-module.exports = function() {
-  var dynamoose = new Dynamoose();
-  var len = middleware.length;
-  for (var i = 0; i < len; i++) {
-    var usefn = middleware[i];
-    usefn(dynamoose);
-  }
-  return dynamoose;
-}
+module.exports = new Dynamoose();

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,8 @@ var Model = require('./Model');
 
 var debug = require('debug')('dynamoose');
 
+var middleware = [];
+
 function Dynamoose () {
   this.models = {};
 
@@ -78,8 +80,20 @@ Dynamoose.prototype.setDefaults = function (options) {
   this.defaults = options;
 };
 
+Dynamoose.prototype.use = function (usefn) {
+  middleware.push(usefn);
+}
+
 Dynamoose.prototype.Schema = Schema;
 Dynamoose.prototype.Table = require('./Table');
 Dynamoose.prototype.Dynamoose = Dynamoose;
 
-module.exports = new Dynamoose();
+module.exports = function() {
+  var dynamoose = new Dynamoose();
+  var len = middleware.length;
+  for (var i = 0; i < len; i++) {
+    var usefn = middleware[i];
+    usefn(dynamoose);
+  }
+  return dynamoose;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,8 +5,6 @@ var Model = require('./Model');
 
 var debug = require('debug')('dynamoose');
 
-var middleware = [];
-
 function Dynamoose () {
   this.models = {};
 
@@ -82,7 +80,7 @@ Dynamoose.prototype.setDefaults = function (options) {
 
 Dynamoose.prototype.use = function (usefn) {
   usefn(module.exports);
-}
+};
 
 Dynamoose.prototype.Schema = Schema;
 Dynamoose.prototype.Table = require('./Table');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamoose",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Dynamoose is a modeling tool for Amazon's DynamoDB (inspired by Mongoose)",
   "homepage": "https://github.com/automategreen/dynamoose",
   "repository": {


### PR DESCRIPTION
This change allows maps to store arbitrary sets of child elements as long as the property names of those elements match a regex named attribute.   If there are two or more regex named attributes in the map that are mutually exclusive, the map may contain two or more types of data.  Regex named attributes and ordinary named attributes can coexist in the same map allowing there to be single instances of some data, and multiple instances of other.

Example:

```
myMap: {
  type: 'map',
  map: {
    "/.*/" : {
      type: 'map',
      map: {
        name: String
      }
    }
  }
```

This matches the following JSON:

```
myMap: {
  Foo: { name : "Foo" },
  Bar: { name: "Bar" },
  Too: { name: "Too" }
} 
```

This essentially turns maps into dynamic sets, allowing you to store sets of multiple arbitrarily complex nested json items in a dynamodb set.

A typical use scenario is creating a 'map' in a schema that is keyed by either a record hashKey or some other unique id (uuid?) that stores some sort form of cached information for that item.  

Note that the dynamodb update() method can insert and remove items from these maps at any level in the hierarchy using the $PUT command.   To add you $PUT the data for a given map key, to remove you $PUT a null value for that key.

```
// Add item to map
MyModel.update({ id: "00012341234" }, { $PUT: { "myMap.Foo" : { name: "Foo" } } });

// Remove item from map
MyModel.update({ id: "00012341234" }, { $PUT: { "myMap.Foo" : null } });
```
