### PR TITLE
Fix missing 'new' when throwing errors.QueryError in Query.js

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -237,7 +237,7 @@ Query.prototype.exec = function (next) {
 
 Query.prototype.where = function (rangeKey) {
   if(this.buildState) {
-    throw errors.QueryError('Invalid query state; where() must follow eq()');
+    throw new errors.QueryError('Invalid query state; where() must follow eq()');
   }
   if(typeof rangeKey === 'string') {
     this.buildState = 'rangeKey';
@@ -259,13 +259,13 @@ Query.prototype.where = function (rangeKey) {
 
 Query.prototype.filter = function (filter) {
   if(this.buildState) {
-    throw errors.QueryError('Invalid query state; filter() must follow comparison');
+    throw new errors.QueryError('Invalid query state; filter() must follow comparison');
   }
   if(typeof filter === 'string') {
     this.buildState = 'filter';
     this.currentFilter = filter;
     if(this.filters[filter]) {
-      throw errors.QueryError('Invalid query state; %s filter can only be used once', filter);
+      throw new errors.QueryError('Invalid query state; %s filter can only be used once', filter);
     }
     this.filters[filter] = {name: filter};
   }
@@ -277,12 +277,12 @@ var VALID_RANGE_KEYS = ['EQ', 'LE', 'LT', 'GE', 'GT', 'BEGINS_WITH', 'BETWEEN'];
 Query.prototype.compVal = function (vals, comp) {
   if(this.buildState === 'hashKey') {
     if(comp !== 'EQ') {
-      throw errors.QueryError('Invalid query state; eq must follow query()');
+      throw new errors.QueryError('Invalid query state; eq must follow query()');
     }
     this.query.hashKey.value = vals[0];
   } else if (this.buildState === 'rangeKey'){
     if(VALID_RANGE_KEYS.indexOf(comp) < 0) {
-      throw errors.QueryError('Invalid query state; %s must follow filter()', comp);
+      throw new errors.QueryError('Invalid query state; %s must follow filter()', comp);
     }
     this.query.rangeKey.values = vals;
     this.query.rangeKey.comparison = comp;
@@ -290,7 +290,7 @@ Query.prototype.compVal = function (vals, comp) {
     this.filters[this.currentFilter].values = vals;
     this.filters[this.currentFilter].comparison = comp;
   } else {
-    throw errors.QueryError('Invalid query state; %s must follow query(), where() or filter()', comp);
+    throw new errors.QueryError('Invalid query state; %s must follow query(), where() or filter()', comp);
   }
 
   this.buildState = false;


### PR DESCRIPTION
Looks like there are a few missing 'new's in the Query.js file.  Added them.

Was getting 'undefined' values in catch() when using invalid query expressions.