### PR TITLE
Swap parameter values for put example in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -488,7 +488,7 @@ Updates and existing item in the table. Three types of updates: $PUT, $ADD, and 
 Put is the default behavior.  The two example below are identical.
 
 ```js
-Dog.update({age: 1},{ownerId: 4, name: 'Odie'}, function (err) {
+Dog.update({ownerId: 4, name: 'Odie'}, {age: 1}, function (err) {
   if(err) { return console.log(err); }
   console.log('Just a puppy');
 })


### PR DESCRIPTION
As far as I can tell from testing, the 2 parameters for the first update put example are the wrong way around if both put examples are attempting to set an age for the previously defined id 4 object.