### PR TITLE
Remove reference to testing infrastructure to prevent warnings from javascript packagers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,1 @@
-exports = module.exports = process.env.TEST_COV ?
-  require('./lib-cov') :
-  require('./lib');
+exports = module.exports = require('./lib');


### PR DESCRIPTION
Not sure how you will want to move the other stuff around to continue getting coverage, but having this set up makes WebPack throw errors while bundling.