### PR TITLE
Closes #42 - loosen aws-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "debug": "*",
-    "aws-sdk": "2.1.*",
+    "aws-sdk": "^2.1.0",
     "q": "~1.0.1",
     "hooks": "0.3.2"
   }


### PR DESCRIPTION
## Description
Loosen the AWS-sdk dependency so that duplications don't occur between other libraries that may also rely on AWS-sdk, or a local dependency.

## Motivation and Context
In a project I am working on, we depended on a more recent version of AWS-sdk, but this library was using its own version, so that it can use the same major version, we should loosen the dependency.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)