### PR TITLE
Fixed unhandled validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 .session.vim
 coverage.html
 lib-cov/
+.vscode

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -177,6 +177,7 @@ var applyVirtuals = function(model, schema){
 
 Model.prototype.put = function(options, next) {
   debug('put', this);
+  var deferred = Q.defer();
   options = options || {};
   if(typeof options === 'function') {
     next = options;
@@ -186,10 +187,15 @@ Model.prototype.put = function(options, next) {
     options.overwrite = true;
   }
   var schema = this.$__.schema;
-  var item = {
-    TableName: this.$__.name,
-    Item: schema.toDynamo(this)
-  };
+  try {
+    var item = {
+      TableName: this.$__.name,
+      Item: schema.toDynamo(this)
+    };
+  } catch(err) {
+    deferred.reject(err);
+  }
+
   if(!options.overwrite) {
     item.ConditionExpression = 'attribute_not_exists(' + schema.hashKey.name + ')';
   }
@@ -201,7 +207,6 @@ Model.prototype.put = function(options, next) {
   var model$ = this.$__;
 
   function put() {
-    var deferred = Q.defer();
     model$.base.ddb().putItem(item, function(err) {
       if(err) {
         deferred.reject(err);
@@ -275,11 +280,15 @@ Model.get = function(NewModel, key, options, next) {
     Key: {}
   };
 
-  getReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+  try {
+    getReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
 
-  if(schema.rangeKey) {
-    var rangeKeyName = schema.rangeKey.name;
-    getReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+    if(schema.rangeKey) {
+      var rangeKeyName = schema.rangeKey.name;
+      getReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+    }
+  } catch (err) {
+    deferred.reject(err);
   }
 
   if(options.attributes) {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -186,14 +186,16 @@ Model.prototype.put = function(options, next) {
   if(options.overwrite === null || options.overwrite === undefined) {
     options.overwrite = true;
   }
+
   var schema = this.$__.schema;
+  var item = {
+    TableName: this.$__.name
+  };
   try {
-    var item = {
-      TableName: this.$__.name,
-      Item: schema.toDynamo(this)
-    };
+    item.Item = schema.toDynamo(this);
   } catch(err) {
     deferred.reject(err);
+    return deferred.promise.nodeify(next);
   }
 
   if(!options.overwrite) {
@@ -289,6 +291,7 @@ Model.get = function(NewModel, key, options, next) {
     }
   } catch (err) {
     deferred.reject(err);
+    return deferred.promise.nodeify(next);
   }
 
   if(options.attributes) {
@@ -393,6 +396,7 @@ Model.update = function(NewModel, key, update, options, next) {
     }
   } catch(err) {
     deferred.reject(err);
+    return deferred.promise.nodeify(next);
   }
 
   // determine the set of operations to be executed
@@ -424,6 +428,7 @@ Model.update = function(NewModel, key, update, options, next) {
             operations.SET[putItem] = putAttr.toDynamo(val);
           } catch (err) {
             deferred.reject(err);
+            return deferred.promise.nodeify(next);
           }
         }
       }
@@ -440,6 +445,7 @@ Model.update = function(NewModel, key, update, options, next) {
             operations.REMOVE[deleteItem] = deleteAttr.toDynamo(delVal);
           } catch (err) {
             deferred.reject(err);
+            return deferred.promise.nodeify(next);
           }
         } else {
           operations.REMOVE[deleteItem] = null;
@@ -456,6 +462,7 @@ Model.update = function(NewModel, key, update, options, next) {
           operations.ADD[addItem] = addAttr.toDynamo(update.$ADD[addItem]);
         } catch (err) {
           deferred.reject(err);
+          return deferred.promise.nodeify(next);
         }
       }
     }
@@ -600,6 +607,7 @@ Model.prototype.delete = function(options, next) {
     }
   } catch (err) {
     deferred.reject(err);
+    return deferred.promise.nodeify(next);
   }
 
   if(options.update) {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -575,11 +575,15 @@ Model.prototype.delete = function(options, next) {
     Key: {}
   };
 
-  getDelete.Key[hashKeyName] = schema.hashKey.toDynamo(this[hashKeyName]);
+  try {
+    getDelete.Key[hashKeyName] = schema.hashKey.toDynamo(this[hashKeyName]);
 
-  if(schema.rangeKey) {
-    var rangeKeyName = schema.rangeKey.name;
-    getDelete.Key[rangeKeyName] = schema.rangeKey.toDynamo(this[rangeKeyName]);
+    if(schema.rangeKey) {
+      var rangeKeyName = schema.rangeKey.name;
+      getDelete.Key[rangeKeyName] = schema.rangeKey.toDynamo(this[rangeKeyName]);
+    }
+  } catch (err) {
+    deferred.reject(err);
   }
 
   if(options.update) {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -384,11 +384,15 @@ Model.update = function(NewModel, key, update, options, next) {
   };
   processCondition(updateReq, options, NewModel.$__.schema);
 
-  updateReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+  try {
+    updateReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
 
-  if(schema.rangeKey) {
-    var rangeKeyName = schema.rangeKey.name;
-    updateReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+    if(schema.rangeKey) {
+      var rangeKeyName = schema.rangeKey.name;
+      updateReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+    }
+  } catch(err) {
+    deferred.reject(err);
   }
 
   // determine the set of operations to be executed
@@ -416,7 +420,11 @@ Model.update = function(NewModel, key, update, options, next) {
         if(removeParams) {
           operations.REMOVE[putItem] = null;
         } else {
-          operations.SET[putItem] = putAttr.toDynamo(val);
+          try {
+            operations.SET[putItem] = putAttr.toDynamo(val);
+          } catch (err) {
+            deferred.reject(err);
+          }
         }
       }
     }
@@ -428,7 +436,11 @@ Model.update = function(NewModel, key, update, options, next) {
       if(deleteAttr) {
         var delVal = update.$DELETE[deleteItem];
         if(delVal !== null && delVal !== undefined) {
-          operations.REMOVE[deleteItem] = deleteAttr.toDynamo(delVal);
+          try {
+            operations.REMOVE[deleteItem] = deleteAttr.toDynamo(delVal);
+          } catch (err) {
+            deferred.reject(err);
+          }
         } else {
           operations.REMOVE[deleteItem] = null;
         }
@@ -440,7 +452,11 @@ Model.update = function(NewModel, key, update, options, next) {
     for(var addItem in update.$ADD) {
       var addAttr = schema.attributes[addItem];
       if(addAttr) {
-        operations.ADD[addItem] = addAttr.toDynamo(update.$ADD[addItem]);
+        try {
+          operations.ADD[addItem] = addAttr.toDynamo(update.$ADD[addItem]);
+        } catch (err) {
+          deferred.reject(err);
+        }
       }
     }
   }

--- a/test/Model.js
+++ b/test/Model.js
@@ -45,7 +45,7 @@ describe('Model', function (){
       array: Array,
       validated: {
         type: String,
-        validate: function (v) { return v == 'valid'; }
+        validate: function (v) { return v === 'valid'; }
       }
     },
     {useDocumentTypes: true});
@@ -593,6 +593,7 @@ describe('Model', function (){
     it('With invalid attribute', function (done) {
       Cat.update({id: 999}, {name: 'Oliver', validated: 'bad'}, function (err, data) {
         should.exist(err);
+        should.not.exist(data);
         err.name.should.equal('ValidationError');
         Cat.get(999, function (err, tomcat) {
           should.not.exist(err);

--- a/test/Model.js
+++ b/test/Model.js
@@ -304,7 +304,7 @@ describe('Model', function (){
       should.exist(model);
 
       model.validated = 'test';
-      model.save(function (err) {
+      model.save().catch(function(err) {
         should.exist(err);
         err.name.should.equal('ValidationError');
         done();
@@ -317,6 +317,17 @@ describe('Model', function (){
     var cat = new Cat({id: 1});
 
     cat.delete(done);
+  });
+
+  it('Deletes item with invalid key', function (done) {
+
+    var cat = new Cat({id: 0});
+
+    cat.delete(function(err) {
+      should.exist(err);
+      err.name.should.equal('ValidationError');
+      done();
+    });
   });
 
   it('Get missing item', function (done) {


### PR DESCRIPTION
Issue: Attribute.toDynamo would throw an unhandled exception when a validation error was triggered, bypassing the promise handling.

Solution: try-catch calls to Attribute.toDynamo and handle them with deferred.reject(err).