### PR TITLE
Handle thrown errors and pass them to callbacks and promises

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -561,7 +561,6 @@ Model.update = function(NewModel, key, update, options, next) {
 
       var model = new NewModel();
       model.$__.isNew = false;
-
       schema.parseDynamo(model, data.Attributes);
 
       debug('updateItem parsed model', model);
@@ -785,16 +784,12 @@ Model.batchGet = function(NewModel, keys, options, next) {
 
   getReq.Keys = keys.map(function (key) {
     var ret = {};
-    schema.parseDynamo(model, data.Attributes);
-    debug('deleteItem parsed model', model);
-
     ret[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
 
     if(schema.rangeKey) {
       var rangeKeyName = schema.rangeKey.name;
       ret[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
     }
-
     return ret;
   });
 
@@ -824,8 +819,8 @@ Model.batchGet = function(NewModel, keys, options, next) {
       function toModel (item) {
         var model = new NewModel();
         model.$__.isNew = false;
-
         schema.parseDynamo(model, item);
+
         debug('batchGet parsed model', model);
 
         return model;
@@ -836,7 +831,6 @@ Model.batchGet = function(NewModel, keys, options, next) {
         // convert unprocessed keys back to dynamoose format
         models.unprocessed = data.UnprocessedKeys[newModel$.name].Keys.map(function (key) {
           var ret = {};
-
           ret[hashKeyName] = schema.hashKey.parseDynamo(key[hashKeyName]);
 
           if(schema.rangeKey) {
@@ -994,7 +988,6 @@ Model.batchDelete = function(NewModel, keys, options, next) {
 
   var batchRequests = toBatchChunks(newModel$.name, keys, MAX_BATCH_WRITE_SIZE, function(key) {
     var key_element = {};
-
     key_element[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
 
     if(schema.rangeKey) {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -75,7 +75,7 @@ Model.compile = function compile (name, schema, options, base) {
     try {
       return Model.get(NewModel, key, options, next);
     } catch(err) {
-      next(err);
+      sendErrorToCallback(err, options, next);
       return Q.reject(err);
     }
   };
@@ -84,7 +84,7 @@ Model.compile = function compile (name, schema, options, base) {
     try {
       return Model.update(NewModel, key, update, options, next);
     } catch(err) {
-      next(err);
+      sendErrorToCallback(err, options, next);
       return Q.reject(err);
     }
   };
@@ -93,7 +93,7 @@ Model.compile = function compile (name, schema, options, base) {
     try {
       return Model.delete(NewModel, key, options, next);
     } catch(err) {
-      next(err);
+      sendErrorToCallback(err, options, next);
       return Q.reject(err);
     }
   };
@@ -102,7 +102,7 @@ Model.compile = function compile (name, schema, options, base) {
     try {
       return Model.query(NewModel, query, options, next);
     } catch(err) {
-      next(err);
+      sendErrorToCallback(err, options, next);
       return Q.reject(err);
     }
   };
@@ -111,7 +111,7 @@ Model.compile = function compile (name, schema, options, base) {
     try {
       return Model.queryOne(NewModel, query, options, next);
     } catch(err) {
-      next(err);
+      sendErrorToCallback(err, options, next);
       return Q.reject(err);
     }
   };
@@ -120,7 +120,7 @@ Model.compile = function compile (name, schema, options, base) {
     try {
       return Model.scan(NewModel, filter, options, next);
     } catch(err) {
-      next(err);
+      sendErrorToCallback(err, options, next);
       return Q.reject(err);
     }
   };
@@ -129,7 +129,7 @@ Model.compile = function compile (name, schema, options, base) {
     try {
       return Model.create(NewModel, obj, options, next);
     } catch(err) {
-      next(err);
+      sendErrorToCallback(err, options, next);
       return Q.reject(err);
     }
   };
@@ -138,7 +138,7 @@ Model.compile = function compile (name, schema, options, base) {
     try {
       return Model.batchGet(NewModel, keys, options, next);
     } catch(err) {
-      next(err);
+      sendErrorToCallback(err, options, next);
       return Q.reject(err);
     }
   };
@@ -147,7 +147,7 @@ Model.compile = function compile (name, schema, options, base) {
     try {
       return Model.batchPut(NewModel, keys, options, next);
     } catch(err) {
-      next(err);
+      sendErrorToCallback(err, options, next);
       return Q.reject(err);
     }
   };
@@ -156,7 +156,7 @@ Model.compile = function compile (name, schema, options, base) {
     try {
       return Model.batchDelete(NewModel, keys, options, next);
     } catch(err) {
-      next(err);
+      sendErrorToCallback(err, options, next);
       return Q.reject(err);
     }
   };
@@ -183,6 +183,13 @@ Model.compile = function compile (name, schema, options, base) {
 
   return NewModel;
 };
+
+function sendErrorToCallback(error, options, next) {
+  if(typeof options === 'function') {
+    next = options;
+  }
+  next(error);
+}
 
 
 /*!
@@ -297,14 +304,16 @@ Model.create = function(NewModel, obj, options, next) {
 Model.get = function(NewModel, key, options, next) {
   debug('Get %j', key);
   var deferred = Q.defer();
-  if(key === null || key === undefined) {
-    deferred.reject(new errors.ModelError('Key required to get item'));
-    return deferred.promise.nodeify(next);
-  }
+
   options = options || {};
   if(typeof options === 'function') {
     next = options;
     options = {};
+  }
+
+  if(key === null || key === undefined) {
+    deferred.reject(new errors.ModelError('Key required to get item'));
+    return deferred.promise.nodeify(next);
   }
 
   var schema = NewModel.$__.schema;

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -228,55 +228,54 @@ var applyVirtuals = function(model, schema){
 Model.prototype.put = function(options, next) {
   debug('put', this);
   var deferred = Q.defer();
-  options = options || {};
-  if(typeof options === 'function') {
-    next = options;
-    options = {};
-  }
-  if(options.overwrite === null || options.overwrite === undefined) {
-    options.overwrite = true;
-  }
 
-  var schema = this.$__.schema;
-  var item = {
-    TableName: this.$__.name
-  };
   try {
-    item.Item = schema.toDynamo(this);
+    options = options || {};
+    if(typeof options === 'function') {
+      next = options;
+      options = {};
+    }
+    if(options.overwrite === null || options.overwrite === undefined) {
+      options.overwrite = true;
+    }
+
+    var schema = this.$__.schema;
+    var item = {
+      TableName: this.$__.name,
+      Item: schema.toDynamo(this)
+    };
+
+    if(!options.overwrite) {
+      item.ConditionExpression = 'attribute_not_exists(' + schema.hashKey.name + ')';
+    }
+    processCondition(item, options, schema);
+
+    debug('putItem', item);
+
+    var model = this;
+    var model$ = this.$__;
+
+    function put() {
+      model$.base.ddb().putItem(item, function(err) {
+        if(err) {
+          deferred.reject(err);
+        }
+        deferred.resolve(model);
+      });
+
+      return deferred.promise.nodeify(next);
+    }
+
+
+    if(model$.options.waitForActive) {
+      return model$.table.waitForActive().then(put);
+    }
+
+    return put();
   } catch(err) {
     deferred.reject(err);
     return deferred.promise.nodeify(next);
   }
-
-  if(!options.overwrite) {
-    item.ConditionExpression = 'attribute_not_exists(' + schema.hashKey.name + ')';
-  }
-  processCondition(item, options, this.$__.schema);
-
-  debug('putItem', item);
-
-  var model = this;
-  var model$ = this.$__;
-
-  function put() {
-    model$.base.ddb().putItem(item, function(err) {
-      if(err) {
-        deferred.reject(err);
-      }
-      deferred.resolve(model);
-    });
-
-    return deferred.promise.nodeify(next);
-  }
-
-
-  if(model$.options.waitForActive) {
-    return model$.table.waitForActive().then(put);
-  }
-
-  return put();
-
-
 };
 
 Model.prototype.save = Model.prototype.put;

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -72,47 +72,102 @@ Model.compile = function compile (name, schema, options, base) {
   NewModel.$__ = NewModel.prototype.$__;
 
   NewModel.get = function (key, options, next) {
-    return Model.get(NewModel, key, options, next);
+    try {
+      return Model.get(NewModel, key, options, next);
+    } catch(err) {
+      next(err);
+      return Q.reject(err);
+    }
   };
 
   NewModel.update = function (key, update, options, next) {
-    return Model.update(NewModel, key, update, options, next);
+    try {
+      return Model.update(NewModel, key, update, options, next);
+    } catch(err) {
+      next(err);
+      return Q.reject(err);
+    }
   };
 
   NewModel.delete = function (key, options, next) {
-    return Model.delete(NewModel, key, options, next);
+    try {
+      return Model.delete(NewModel, key, options, next);
+    } catch(err) {
+      next(err);
+      return Q.reject(err);
+    }
   };
 
   NewModel.query = function (query, options, next) {
-    return Model.query(NewModel, query, options, next);
+    try {
+      return Model.query(NewModel, query, options, next);
+    } catch(err) {
+      next(err);
+      return Q.reject(err);
+    }
   };
 
   NewModel.queryOne = function (query, options, next) {
-    return Model.queryOne(NewModel, query, options, next);
+    try {
+      return Model.queryOne(NewModel, query, options, next);
+    } catch(err) {
+      next(err);
+      return Q.reject(err);
+    }
   };
 
   NewModel.scan = function (filter, options, next) {
-    return Model.scan(NewModel, filter, options, next);
+    try {
+      return Model.scan(NewModel, filter, options, next);
+    } catch(err) {
+      next(err);
+      return Q.reject(err);
+    }
   };
 
   NewModel.create = function (obj, options, next) {
-    return Model.create(NewModel, obj, options, next);
+    try {
+      return Model.create(NewModel, obj, options, next);
+    } catch(err) {
+      next(err);
+      return Q.reject(err);
+    }
   };
 
   NewModel.batchGet = function (keys, options, next) {
-    return Model.batchGet(NewModel, keys, options, next);
+    try {
+      return Model.batchGet(NewModel, keys, options, next);
+    } catch(err) {
+      next(err);
+      return Q.reject(err);
+    }
   };
 
   NewModel.batchPut = function (keys, options, next) {
-    return Model.batchPut(NewModel, keys, options, next);
+    try {
+      return Model.batchPut(NewModel, keys, options, next);
+    } catch(err) {
+      next(err);
+      return Q.reject(err);
+    }
   };
 
   NewModel.batchDelete = function (keys, options, next) {
-    return Model.batchDelete(NewModel, keys, options, next);
+    try {
+      return Model.batchDelete(NewModel, keys, options, next);
+    } catch(err) {
+      next(err);
+      return Q.reject(err);
+    }
   };
 
   NewModel.waitForActive = function (timeout, next) {
-    return table.waitForActive(timeout, next);
+    try {
+      return table.waitForActive(timeout, next);
+    } catch(err) {
+      next(err);
+      return Q.reject(err);
+    }
   };
 
 
@@ -282,16 +337,11 @@ Model.get = function(NewModel, key, options, next) {
     Key: {}
   };
 
-  try {
-    getReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+  getReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
 
-    if(schema.rangeKey) {
-      var rangeKeyName = schema.rangeKey.name;
-      getReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
-    }
-  } catch (err) {
-    deferred.reject(err);
-    return deferred.promise.nodeify(next);
+  if(schema.rangeKey) {
+    var rangeKeyName = schema.rangeKey.name;
+    getReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
   }
 
   if(options.attributes) {
@@ -318,18 +368,14 @@ Model.get = function(NewModel, key, options, next) {
         return deferred.resolve();
       }
 
-      try {
-        var model = new NewModel();
+      var model = new NewModel();
 
-        model.$__.isNew = false;
-        schema.parseDynamo(model, data.Item);
+      model.$__.isNew = false;
+      schema.parseDynamo(model, data.Item);
 
-        debug('getItem parsed model', model);
+      debug('getItem parsed model', model);
 
-        deferred.resolve(model);
-      } catch (err) {
-        deferred.reject(err);
-      }
+      deferred.resolve(model);
     });
   }
 
@@ -387,16 +433,11 @@ Model.update = function(NewModel, key, update, options, next) {
   };
   processCondition(updateReq, options, NewModel.$__.schema);
 
-  try {
-    updateReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+  updateReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
 
-    if(schema.rangeKey) {
-      var rangeKeyName = schema.rangeKey.name;
-      updateReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
-    }
-  } catch(err) {
-    deferred.reject(err);
-    return deferred.promise.nodeify(next);
+  if(schema.rangeKey) {
+    var rangeKeyName = schema.rangeKey.name;
+    updateReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
   }
 
   // update the 'updatedAt' timestamp if requested
@@ -429,12 +470,7 @@ Model.update = function(NewModel, key, update, options, next) {
         if(removeParams) {
           operations.REMOVE[putItem] = null;
         } else {
-          try {
-            operations.SET[putItem] = putAttr.toDynamo(val);
-          } catch (err) {
-            deferred.reject(err);
-            return deferred.promise.nodeify(next);
-          }
+          operations.SET[putItem] = putAttr.toDynamo(val);
         }
       }
     }
@@ -446,12 +482,7 @@ Model.update = function(NewModel, key, update, options, next) {
       if(deleteAttr) {
         var delVal = update.$DELETE[deleteItem];
         if(delVal !== null && delVal !== undefined) {
-          try {
-            operations.REMOVE[deleteItem] = deleteAttr.toDynamo(delVal);
-          } catch (err) {
-            deferred.reject(err);
-            return deferred.promise.nodeify(next);
-          }
+          operations.REMOVE[deleteItem] = deleteAttr.toDynamo(delVal);
         } else {
           operations.REMOVE[deleteItem] = null;
         }
@@ -463,12 +494,7 @@ Model.update = function(NewModel, key, update, options, next) {
     for(var addItem in update.$ADD) {
       var addAttr = schema.attributes[addItem];
       if(addAttr) {
-        try {
-          operations.ADD[addItem] = addAttr.toDynamo(update.$ADD[addItem]);
-        } catch (err) {
-          deferred.reject(err);
-          return deferred.promise.nodeify(next);
-        }
+        operations.ADD[addItem] = addAttr.toDynamo(update.$ADD[addItem]);
       }
     }
   }
@@ -536,11 +562,7 @@ Model.update = function(NewModel, key, update, options, next) {
       var model = new NewModel();
       model.$__.isNew = false;
 
-      try {
-        schema.parseDynamo(model, data.Attributes);
-      } catch (err) {
-        deferred.reject(err)
-      }
+      schema.parseDynamo(model, data.Attributes);
 
       debug('updateItem parsed model', model);
 
@@ -608,16 +630,11 @@ Model.prototype.delete = function(options, next) {
     Key: {}
   };
 
-  try {
-    getDelete.Key[hashKeyName] = schema.hashKey.toDynamo(this[hashKeyName]);
+  getDelete.Key[hashKeyName] = schema.hashKey.toDynamo(this[hashKeyName]);
 
-    if(schema.rangeKey) {
-      var rangeKeyName = schema.rangeKey.name;
-      getDelete.Key[rangeKeyName] = schema.rangeKey.toDynamo(this[rangeKeyName]);
-    }
-  } catch (err) {
-    deferred.reject(err);
-    return deferred.promise.nodeify(next);
+  if(schema.rangeKey) {
+    var rangeKeyName = schema.rangeKey.name;
+    getDelete.Key[rangeKeyName] = schema.rangeKey.toDynamo(this[rangeKeyName]);
   }
 
   if(options.update) {
@@ -640,12 +657,8 @@ Model.prototype.delete = function(options, next) {
 
       if(options.update) {
         if(data.Attributes) {
-          try {
-            schema.parseDynamo(model, data.Attributes);
-            debug('deleteItem parsed model', model);
-          } catch(err) {
-            deferred.reject(err);
-          }
+          schema.parseDynamo(model, data.Attributes);
+          debug('deleteItem parsed model', model);
         }
       }
 
@@ -772,21 +785,17 @@ Model.batchGet = function(NewModel, keys, options, next) {
 
   getReq.Keys = keys.map(function (key) {
     var ret = {};
-    try {
-      schema.parseDynamo(model, data.Attributes);
-      debug('deleteItem parsed model', model);
+    schema.parseDynamo(model, data.Attributes);
+    debug('deleteItem parsed model', model);
 
-      ret[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+    ret[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
 
-      if(schema.rangeKey) {
-        var rangeKeyName = schema.rangeKey.name;
-        ret[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
-      }
-
-      return ret;
-    } catch(err) {
-      deferred.reject(err);
+    if(schema.rangeKey) {
+      var rangeKeyName = schema.rangeKey.name;
+      ret[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
     }
+
+    return ret;
   });
 
   if(options.attributes) {
@@ -816,14 +825,10 @@ Model.batchGet = function(NewModel, keys, options, next) {
         var model = new NewModel();
         model.$__.isNew = false;
 
-        try {
-          schema.parseDynamo(model, item);
-          debug('batchGet parsed model', model);
+        schema.parseDynamo(model, item);
+        debug('batchGet parsed model', model);
 
-          return model;
-        } catch(err) {
-          deferred.reject(err);
-        }
+        return model;
       }
 
       var models = data.Responses[newModel$.name] ? data.Responses[newModel$.name].map(toModel) : [];
@@ -832,17 +837,13 @@ Model.batchGet = function(NewModel, keys, options, next) {
         models.unprocessed = data.UnprocessedKeys[newModel$.name].Keys.map(function (key) {
           var ret = {};
 
-          try {
-            ret[hashKeyName] = schema.hashKey.parseDynamo(key[hashKeyName]);
+          ret[hashKeyName] = schema.hashKey.parseDynamo(key[hashKeyName]);
 
-            if(schema.rangeKey) {
-              var rangeKeyName = schema.rangeKey.name;
-              ret[rangeKeyName] = schema.rangeKey.parseDynamo(key[rangeKeyName]);
-            }
-            return ret;
-          } catch(err) {
-            deferred.reject(err);
+          if(schema.rangeKey) {
+            var rangeKeyName = schema.rangeKey.name;
+            ret[rangeKeyName] = schema.rangeKey.parseDynamo(key[rangeKeyName]);
           }
+          return ret;
         });
       }
       deferred.resolve(models);
@@ -949,16 +950,11 @@ Model.batchPut = function(NewModel, items, options, next) {
   var newModel$ = NewModel.$__;
 
   var batchRequests = toBatchChunks(newModel$.name, items, MAX_BATCH_WRITE_SIZE, function(item) {
-    try {
-      return {
-        PutRequest: {
-          Item: schema.toDynamo(item)
-        }
-      };
-    } catch (err) {
-      deferred.reject(err);
-    }
-
+    return {
+      PutRequest: {
+        Item: schema.toDynamo(item)
+      }
+    };
   });
 
   var batchPut = function() {
@@ -999,11 +995,9 @@ Model.batchDelete = function(NewModel, keys, options, next) {
   var batchRequests = toBatchChunks(newModel$.name, keys, MAX_BATCH_WRITE_SIZE, function(key) {
     var key_element = {};
 
-    // TODO: can throw
     key_element[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
 
     if(schema.rangeKey) {
-      // TODO: can throw
       key_element[schema.rangeKey.name] = schema.rangeKey.toDynamo(key[schema.rangeKey.name]);
     }
 

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -186,28 +186,35 @@ Model.prototype.put = function(options, next) {
     options.overwrite = true;
   }
   var schema = this.$__.schema;
-  var item = {
-    TableName: this.$__.name,
-    Item: schema.toDynamo(this)
-  };
-  if(!options.overwrite) {
-    item.ConditionExpression = 'attribute_not_exists(' + schema.hashKey.name + ')';
-  }
-  processCondition(item, options, this.$__.schema);
-
-  debug('putItem', item);
 
   var model = this;
   var model$ = this.$__;
+  var tableName = this.$__.name;
 
   function put() {
     var deferred = Q.defer();
-    model$.base.ddb().putItem(item, function(err) {
-      if(err) {
-        deferred.reject(err);
+
+    try {
+      var item = {
+        TableName: tableName,
+        Item: schema.toDynamo(model)
+      };
+      if(!options.overwrite) {
+        item.ConditionExpression = 'attribute_not_exists(' + schema.hashKey.name + ')';
       }
-      deferred.resolve(model);
-    });
+      processCondition(item, options, schema);
+
+      debug('putItem', item);
+
+      model$.base.ddb().putItem(item, function(err) {
+        if(err) {
+          deferred.reject(err);
+        }
+        deferred.resolve(model);
+      });
+    } catch (err) {
+      deferred.reject(err);
+    }
 
     return deferred.promise.nodeify(next);
   }
@@ -275,11 +282,15 @@ Model.get = function(NewModel, key, options, next) {
     Key: {}
   };
 
-  getReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+  try {
+    getReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
 
-  if(schema.rangeKey) {
-    var rangeKeyName = schema.rangeKey.name;
-    getReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+    if(schema.rangeKey) {
+      var rangeKeyName = schema.rangeKey.name;
+      getReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+    }
+  } catch (err) {
+    return deferred.reject(err);
   }
 
   if(options.attributes) {
@@ -373,13 +384,18 @@ Model.update = function(NewModel, key, update, options, next) {
     ExpressionAttributeValues: {},
     ReturnValues: 'ALL_NEW'
   };
-  processCondition(updateReq, options, NewModel.$__.schema);
 
-  updateReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+  try {
+    processCondition(updateReq, options, NewModel.$__.schema);
 
-  if(schema.rangeKey) {
-    var rangeKeyName = schema.rangeKey.name;
-    updateReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+    updateReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+
+    if(schema.rangeKey) {
+      var rangeKeyName = schema.rangeKey.name;
+      updateReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+    }
+  } catch (err) {
+    deferred.reject(err)
   }
 
   // determine the set of operations to be executed
@@ -407,7 +423,11 @@ Model.update = function(NewModel, key, update, options, next) {
         if(removeParams) {
           operations.REMOVE[putItem] = null;
         } else {
-          operations.SET[putItem] = putAttr.toDynamo(val);
+          try {
+            operations.SET[putItem] = putAttr.toDynamo(val);
+          } catch (err) {
+            deferred.reject(err)
+          }
         }
       }
     }
@@ -419,7 +439,11 @@ Model.update = function(NewModel, key, update, options, next) {
       if(deleteAttr) {
         var delVal = update.$DELETE[deleteItem];
         if(delVal !== null && delVal !== undefined) {
-          operations.REMOVE[deleteItem] = deleteAttr.toDynamo(delVal);
+          try {
+            operations.REMOVE[deleteItem] = deleteAttr.toDynamo(delVal);
+          } catch (err) {
+            deferred.reject(err)
+          }
         } else {
           operations.REMOVE[deleteItem] = null;
         }
@@ -431,7 +455,11 @@ Model.update = function(NewModel, key, update, options, next) {
     for(var addItem in update.$ADD) {
       var addAttr = schema.attributes[addItem];
       if(addAttr) {
-        operations.ADD[addItem] = addAttr.toDynamo(update.$ADD[addItem]);
+        try {
+          operations.ADD[addItem] = addAttr.toDynamo(update.$ADD[addItem]);
+        } catch (err) {
+          deferred.reject(err)
+        }
       }
     }
   }
@@ -498,7 +526,12 @@ Model.update = function(NewModel, key, update, options, next) {
 
       var model = new NewModel();
       model.$__.isNew = false;
-      schema.parseDynamo(model, data.Attributes);
+
+      try {
+        schema.parseDynamo(model, data.Attributes);
+      } catch (err) {
+        deferred.reject(err)
+      }
 
       debug('updateItem parsed model', model);
 
@@ -566,11 +599,15 @@ Model.prototype.delete = function(options, next) {
     Key: {}
   };
 
-  getDelete.Key[hashKeyName] = schema.hashKey.toDynamo(this[hashKeyName]);
+  try {
+    getDelete.Key[hashKeyName] = schema.hashKey.toDynamo(this[hashKeyName]);
 
-  if(schema.rangeKey) {
-    var rangeKeyName = schema.rangeKey.name;
-    getDelete.Key[rangeKeyName] = schema.rangeKey.toDynamo(this[rangeKeyName]);
+    if(schema.rangeKey) {
+      var rangeKeyName = schema.rangeKey.name;
+      getDelete.Key[rangeKeyName] = schema.rangeKey.toDynamo(this[rangeKeyName]);
+    }
+  } catch(err) {
+    deferred.reject(err);
   }
 
   if(options.update) {
@@ -593,8 +630,12 @@ Model.prototype.delete = function(options, next) {
 
       if(options.update) {
         if(data.Attributes) {
-          schema.parseDynamo(model, data.Attributes);
-          debug('deleteItem parsed model', model);
+          try {
+            schema.parseDynamo(model, data.Attributes);
+            debug('deleteItem parsed model', model);
+          } catch(err) {
+            deferred.reject(err);
+          }
         }
       }
 
@@ -721,13 +762,21 @@ Model.batchGet = function(NewModel, keys, options, next) {
 
   getReq.Keys = keys.map(function (key) {
     var ret = {};
-    ret[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+    try {
+      schema.parseDynamo(model, data.Attributes);
+      debug('deleteItem parsed model', model);
 
-    if(schema.rangeKey) {
-      var rangeKeyName = schema.rangeKey.name;
-      ret[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+      ret[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+
+      if(schema.rangeKey) {
+        var rangeKeyName = schema.rangeKey.name;
+        ret[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+      }
+
+      return ret;
+    } catch(err) {
+      deferred.reject(err);
     }
-    return ret;
   });
 
   if(options.attributes) {
@@ -756,11 +805,15 @@ Model.batchGet = function(NewModel, keys, options, next) {
       function toModel (item) {
         var model = new NewModel();
         model.$__.isNew = false;
-        schema.parseDynamo(model, item);
 
-        debug('batchGet parsed model', model);
+        try {
+          schema.parseDynamo(model, item);
+          debug('batchGet parsed model', model);
 
-        return model;
+          return model;
+        } catch(err) {
+          deferred.reject(err);
+        }
       }
 
       var models = data.Responses[newModel$.name] ? data.Responses[newModel$.name].map(toModel) : [];
@@ -768,13 +821,18 @@ Model.batchGet = function(NewModel, keys, options, next) {
         // convert unprocessed keys back to dynamoose format
         models.unprocessed = data.UnprocessedKeys[newModel$.name].Keys.map(function (key) {
           var ret = {};
-          ret[hashKeyName] = schema.hashKey.parseDynamo(key[hashKeyName]);
 
-          if(schema.rangeKey) {
-            var rangeKeyName = schema.rangeKey.name;
-            ret[rangeKeyName] = schema.rangeKey.parseDynamo(key[rangeKeyName]);
+          try {
+            ret[hashKeyName] = schema.hashKey.parseDynamo(key[hashKeyName]);
+
+            if(schema.rangeKey) {
+              var rangeKeyName = schema.rangeKey.name;
+              ret[rangeKeyName] = schema.rangeKey.parseDynamo(key[rangeKeyName]);
+            }
+            return ret;
+          } catch(err) {
+            deferred.reject(err);
           }
-          return ret;
         });
       }
       deferred.resolve(models);
@@ -881,11 +939,16 @@ Model.batchPut = function(NewModel, items, options, next) {
   var newModel$ = NewModel.$__;
 
   var batchRequests = toBatchChunks(newModel$.name, items, MAX_BATCH_WRITE_SIZE, function(item) {
-    return {
-      PutRequest: {
-        Item: schema.toDynamo(item)
-      }
-    };
+    try {
+      return {
+        PutRequest: {
+          Item: schema.toDynamo(item)
+        }
+      };
+    } catch (err) {
+      deferred.reject(err);
+    }
+
   });
 
   var batchPut = function() {
@@ -925,9 +988,12 @@ Model.batchDelete = function(NewModel, keys, options, next) {
 
   var batchRequests = toBatchChunks(newModel$.name, keys, MAX_BATCH_WRITE_SIZE, function(key) {
     var key_element = {};
+
+    // TODO: can throw
     key_element[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
 
     if(schema.rangeKey) {
+      // TODO: can throw
       key_element[schema.rangeKey.name] = schema.rangeKey.toDynamo(key[schema.rangeKey.name]);
     }
 

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -229,6 +229,16 @@ Model.prototype.put = function(options, next) {
   debug('put', this);
   var deferred = Q.defer();
 
+  function putItem() {
+    model$.base.ddb().putItem(item, function(err) {
+      if(err) {
+        deferred.reject(err);
+      }
+      deferred.resolve(model);
+    });
+    return deferred.promise.nodeify(next);
+  }
+
   try {
     options = options || {};
     if(typeof options === 'function') {
@@ -255,23 +265,11 @@ Model.prototype.put = function(options, next) {
     var model = this;
     var model$ = this.$__;
 
-    function put() {
-      model$.base.ddb().putItem(item, function(err) {
-        if(err) {
-          deferred.reject(err);
-        }
-        deferred.resolve(model);
-      });
-
-      return deferred.promise.nodeify(next);
-    }
-
-
     if(model$.options.waitForActive) {
-      return model$.table.waitForActive().then(put);
+      return model$.table.waitForActive().then(putItem);
     }
 
-    return put();
+    return putItem();
   } catch(err) {
     deferred.reject(err);
     return deferred.promise.nodeify(next);

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -306,14 +306,18 @@ Model.get = function(NewModel, key, options, next) {
         return deferred.resolve();
       }
 
-      var model = new NewModel();
+      try {
+        var model = new NewModel();
 
-      model.$__.isNew = false;
-      schema.parseDynamo(model, data.Item);
+        model.$__.isNew = false;
+        schema.parseDynamo(model, data.Item);
 
-      debug('getItem parsed model', model);
+        debug('getItem parsed model', model);
 
-      deferred.resolve(model);
+        deferred.resolve(model);
+      } catch (err) {
+        deferred.reject(err);
+      }
     });
   }
 

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -630,11 +630,16 @@ Model.prototype.delete = function(options, next) {
     Key: {}
   };
 
-  getDelete.Key[hashKeyName] = schema.hashKey.toDynamo(this[hashKeyName]);
+  try {
+    getDelete.Key[hashKeyName] = schema.hashKey.toDynamo(this[hashKeyName]);
 
-  if(schema.rangeKey) {
-    var rangeKeyName = schema.rangeKey.name;
-    getDelete.Key[rangeKeyName] = schema.rangeKey.toDynamo(this[rangeKeyName]);
+    if(schema.rangeKey) {
+      var rangeKeyName = schema.rangeKey.name;
+      getDelete.Key[rangeKeyName] = schema.rangeKey.toDynamo(this[rangeKeyName]);
+    }
+  } catch (err) {
+    deferred.reject(err);
+    return deferred.promise.nodeify(next);
   }
 
   if(options.update) {
@@ -655,10 +660,12 @@ Model.prototype.delete = function(options, next) {
       }
       debug('deleteItem response', data);
 
-      if(options.update) {
-        if(data.Attributes) {
+      if(options.update && data.Attributes) {
+        try {
           schema.parseDynamo(model, data.Attributes);
           debug('deleteItem parsed model', model);
+        } catch (err) {
+          return deferred.reject(err);
         }
       }
 

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -162,12 +162,7 @@ Model.compile = function compile (name, schema, options, base) {
   };
 
   NewModel.waitForActive = function (timeout, next) {
-    try {
-      return table.waitForActive(timeout, next);
-    } catch(err) {
-      next(err);
-      return Q.reject(err);
-    }
+    return table.waitForActive(timeout, next);
   };
 
 

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -3,8 +3,6 @@ var Q = require('q');
 var errors = require('./errors');
 var debug = require('debug')('dynamoose:query');
 
-var validationError = null;
-
 function Query (Model, query, options) {
   this.Model = Model;
   this.options = options || {};
@@ -25,6 +23,7 @@ function Query (Model, query, options) {
 
   this.filters = {};
   this.buildState = false;
+  this.validationError = null;
 
   var hashKeyName, hashKeyVal;
   if(typeof query === 'string') {

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -209,18 +209,23 @@ Query.prototype.exec = function (next) {
         return model;
       }
 
+      try {
 
-      var models = data.Items.map(toModel);
+        var models = data.Items.map(toModel);
 
-      if(options.one) {
-        if (!models || models.length === 0) {
-          return deferred.resolve();
+        if(options.one) {
+          if (!models || models.length === 0) {
+            return deferred.resolve();
+          }
+          return deferred.resolve(models[0]);
         }
-        return deferred.resolve(models[0]);
-      }
 
-      models.lastKey = data.LastEvaluatedKey;
-      deferred.resolve(models);
+        models.lastKey = data.LastEvaluatedKey;
+        deferred.resolve(models);
+
+      } catch (err) {
+        deferred.reject(err);
+      }
     });
 
     return deferred.promise.nodeify(next);

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -3,7 +3,7 @@ var Q = require('q');
 var errors = require('./errors');
 var debug = require('debug')('dynamoose:query');
 
-
+var validationError = null;
 
 function Query (Model, query, options) {
   this.Model = Model;
@@ -63,6 +63,12 @@ function Query (Model, query, options) {
 
 
 Query.prototype.exec = function (next) {
+  if (this.validationError) {
+    if (next) {
+      next(this.validationError);
+    }
+    return Q.reject(this.validationError);
+  }
   debug('exec query for ', this.query);
   var Model = this.Model;
   var Model$ = Model.$__;
@@ -241,8 +247,12 @@ Query.prototype.exec = function (next) {
 
 
 Query.prototype.where = function (rangeKey) {
+  if (this.validationError) {
+    return this;
+  }
   if(this.buildState) {
-    throw new errors.QueryError('Invalid query state; where() must follow eq()');
+    this.validationError = new errors.QueryError('Invalid query state; where() must follow eq()');
+    return this;
   }
   if(typeof rangeKey === 'string') {
     this.buildState = 'rangeKey';
@@ -263,14 +273,19 @@ Query.prototype.where = function (rangeKey) {
 };
 
 Query.prototype.filter = function (filter) {
+  if (this.validationError) {
+    return this;
+  }
   if(this.buildState) {
-    throw new errors.QueryError('Invalid query state; filter() must follow comparison');
+    this.validationError = new errors.QueryError('Invalid query state; filter() must follow comparison');
+    return this;
   }
   if(typeof filter === 'string') {
     this.buildState = 'filter';
     this.currentFilter = filter;
     if(this.filters[filter]) {
-      throw new errors.QueryError('Invalid query state; %s filter can only be used once', filter);
+      this.validationError =  new errors.QueryError('Invalid query state; %s filter can only be used once', filter);
+      return this;
     }
     this.filters[filter] = {name: filter};
   }
@@ -280,14 +295,19 @@ Query.prototype.filter = function (filter) {
 
 var VALID_RANGE_KEYS = ['EQ', 'LE', 'LT', 'GE', 'GT', 'BEGINS_WITH', 'BETWEEN'];
 Query.prototype.compVal = function (vals, comp) {
+  if (this.validationError) {
+    return this;
+  }
   if(this.buildState === 'hashKey') {
     if(comp !== 'EQ') {
-      throw new errors.QueryError('Invalid query state; eq must follow query()');
+      this.validationError = new errors.QueryError('Invalid query state; eq must follow query()');
+      return this;
     }
     this.query.hashKey.value = vals[0];
   } else if (this.buildState === 'rangeKey'){
     if(VALID_RANGE_KEYS.indexOf(comp) < 0) {
-      throw new errors.QueryError('Invalid query state; %s must follow filter()', comp);
+      this.validationError =  new errors.QueryError('Invalid query state; %s must follow filter()', comp);
+      return this;
     }
     this.query.rangeKey.values = vals;
     this.query.rangeKey.comparison = comp;
@@ -295,7 +315,8 @@ Query.prototype.compVal = function (vals, comp) {
     this.filters[this.currentFilter].values = vals;
     this.filters[this.currentFilter].comparison = comp;
   } else {
-    throw new errors.QueryError('Invalid query state; %s must follow query(), where() or filter()', comp);
+    this.validationError =  new errors.QueryError('Invalid query state; %s must follow query(), where() or filter()', comp);
+    return this;
   }
 
   this.buildState = false;
@@ -380,23 +401,35 @@ Query.prototype.contains = function (val) {
 };
 
 Query.prototype.beginsWith = function (val) {
+  if (this.validationError) {
+    return this;
+  }
   if(this.notState) {
-    throw new errors.QueryError('Invalid Query state: beginsWith() cannot follow not()');
+    this.validationError =  new errors.QueryError('Invalid Query state: beginsWith() cannot follow not()');
+    return this;
   }
   return this.compVal([val], 'BEGINS_WITH');
 };
 
 Query.prototype.in = function (vals) {
+  if (this.validationError) {
+    return this;
+  }
   if(this.notState) {
-    throw new errors.QueryError('Invalid Query state: in() cannot follow not()');
+    this.validationError = new errors.QueryError('Invalid Query state: in() cannot follow not()');
+    return this;
   }
 
   return this.compVal(vals, 'IN');
 };
 
 Query.prototype.between = function (a, b) {
+  if (this.validationError) {
+    return this;
+  }
   if(this.notState) {
-    throw new errors.QueryError('Invalid Query state: between() cannot follow not()');
+    this.validationError = new errors.QueryError('Invalid Query state: between() cannot follow not()');
+    return this;
   }
   return this.compVal([a, b], 'BETWEEN');
 };

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -63,13 +63,14 @@ function Query (Model, query, options) {
 
 
 Query.prototype.exec = function (next) {
+  debug('exec query for ', this.query);
   if (this.validationError) {
     if (next) {
       next(this.validationError);
     }
     return Q.reject(this.validationError);
   }
-  debug('exec query for ', this.query);
+
   var Model = this.Model;
   var Model$ = Model.$__;
   var schema = Model$.schema;

--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -3,6 +3,9 @@ var Q = require('q');
 var debug = require('debug')('dynamoose:scan');
 
 var errors = require('./errors');
+
+var validationError = null;
+
 function Scan (Model, filter, options) {
 
   this.Model = Model;
@@ -31,6 +34,13 @@ function Scan (Model, filter, options) {
 
 Scan.prototype.exec = function (next) {
   debug('exec scan for ', this.scan);
+  if (this.validationError) {
+    if (next) {
+      next(this.validationError);
+    }
+    return Q.reject(this.validationError);
+  }
+
   var Model = this.Model;
   var Model$ = Model.$__;
   var schema = Model$.schema;
@@ -185,13 +195,19 @@ Scan.prototype.or = function() {
 
 
 Scan.prototype.where = function (filter) {
+  if (this.validationError) {
+    return this;
+  }
+
   if(this.buildState) {
-    throw new errors.ScanError('Invalid scan state; where() must follow comparison');
+    this.validationError = new errors.ScanError('Invalid scan state; where() must follow comparison');
+    return this;
   }
   if(typeof filter === 'string') {
     this.buildState = filter;
     if(this.filters[filter]) {
-      throw new errors.ScanError('Invalid scan state; %s can only be used once', filter);
+      this.validationError = new errors.ScanError('Invalid scan state; %s can only be used once', filter);
+      return this
     }
     this.filters[filter] = {name: filter};
   }
@@ -201,6 +217,9 @@ Scan.prototype.where = function (filter) {
 Scan.prototype.filter = Scan.prototype.where;
 
 Scan.prototype.compVal = function (vals, comp) {
+  if (this.validationError) {
+    return this;
+  }
 
   var permittedComparison =
     [
@@ -210,11 +229,13 @@ Scan.prototype.compVal = function (vals, comp) {
 
 
   if(!this.buildState) {
-    throw new errors.ScanError('Invalid scan state; %s must follow scan(), where(), or filter()', comp);
+    this.validationError = new errors.ScanError('Invalid scan state; %s must follow scan(), where(), or filter()', comp);
+    return this;
   }
 
   if (permittedComparison.indexOf(comp) === -1) {
-    throw new errors.ScanError('Invalid comparison %s', comp);
+    this.validationError = new errors.ScanError('Invalid comparison %s', comp);
+    return this;
   }
 
   this.filters[this.buildState].values = vals;
@@ -291,23 +312,35 @@ Scan.prototype.contains = function (val) {
 };
 
 Scan.prototype.beginsWith = function (val) {
+  if (this.validationError) {
+    return this;
+  }
   if(this.notState) {
-    throw new errors.ScanError('Invalid scan state: beginsWith() cannot follow not()');
+    this.validationError = new errors.ScanError('Invalid scan state: beginsWith() cannot follow not()');
+    return this;
   }
   return this.compVal([val], 'BEGINS_WITH');
 };
 
 Scan.prototype.in = function (vals) {
+  if (this.validationError) {
+    return this;
+  }
   if(this.notState) {
-    throw new errors.ScanError('Invalid scan state: in() cannot follow not()');
+    this.validationError = new errors.ScanError('Invalid scan state: in() cannot follow not()');
+    return this;
   }
 
   return this.compVal(vals, 'IN');
 };
 
 Scan.prototype.between = function (a, b) {
+  if (this.validationError) {
+    return this;
+  }
   if(this.notState) {
-    throw new errors.ScanError('Invalid scan state: between() cannot follow not()');
+    this.validationError = new errors.ScanError('Invalid scan state: between() cannot follow not()');
+    return this;
   }
   return this.compVal([a, b], 'BETWEEN');
 };

--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -4,8 +4,6 @@ var debug = require('debug')('dynamoose:scan');
 
 var errors = require('./errors');
 
-var validationError = null;
-
 function Scan (Model, filter, options) {
 
   this.Model = Model;
@@ -21,6 +19,7 @@ function Scan (Model, filter, options) {
   // ]
   this.filters = {};
   this.buildState = false;
+  this.validationError = null;
 
   if (typeof filter === 'string') {
     this.buildState = filter;
@@ -207,7 +206,7 @@ Scan.prototype.where = function (filter) {
     this.buildState = filter;
     if(this.filters[filter]) {
       this.validationError = new errors.ScanError('Invalid scan state; %s can only be used once', filter);
-      return this
+      return this;
     }
     this.filters[filter] = {name: filter};
   }

--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -102,11 +102,14 @@ Scan.prototype.exec = function (next) {
         return model;
       }
 
+      try {
+        var models = data.Items.map(toModel);
 
-      var models = data.Items.map(toModel);
-
-      models.lastKey = data.LastEvaluatedKey;
-      deferred.resolve(models);
+        models.lastKey = data.LastEvaluatedKey;
+        deferred.resolve(models);
+      } catch (err) {
+        deferred.reject(err);
+      }
     });
 
     return deferred.promise.nodeify(next);

--- a/test/Scan.js
+++ b/test/Scan.js
@@ -467,10 +467,11 @@ describe('Scan', function (){
     var Dog = dynamoose.model('Dog');
 
     (function() {
-      Dog.scan('name').not().beginsWith('B').exec(function () {
-        should.not.exist(true);
+      Dog.scan('name').not().beginsWith('B').exec(function (err) {
+        should.exist(err);
+        err.code.should.eql('Invalid scan state: beginsWith() cannot follow not()');
       });
-    }).should.throw('Invalid scan state: beginsWith() cannot follow not()');
+    });
     done();
   });
 
@@ -499,10 +500,11 @@ describe('Scan', function (){
     var Dog = dynamoose.model('Dog');
 
     (function() {
-      Dog.scan('name').not().in(['Beagle', 'Hound']).exec(function () {
-        should.not.exist(true);
+      Dog.scan('name').not().in(['Beagle', 'Hound']).exec(function (err) {
+        should.exist(err);
+        err.code.should.eql('Invalid scan state: in() cannot follow not()');
       });
-    }).should.throw('Invalid scan state: in() cannot follow not()');
+    });
     done();
   });
 
@@ -531,10 +533,11 @@ describe('Scan', function (){
     var Dog = dynamoose.model('Dog');
 
     (function() {
-      Dog.scan('ownerId').not().between(5, 8).exec(function () {
-        should.not.exist(true);
+      Dog.scan('ownerId').not().between(5, 8).exec(function (err) {
+        should.exist(err);
+        err.code.should.eql('Invalid scan state: between() cannot follow not()');
       });
-    }).should.throw('Invalid scan state: between() cannot follow not()');
+    });
     done();
   });
 
@@ -597,10 +600,11 @@ describe('Scan', function (){
     var Dog = dynamoose.model('Dog');
 
     (function() {
-      Dog.scan({and:[{'breed': {eq: 'unknown'}},{'breed':{eq:'Benji'}}]},function () {
-        should.not.exist(true);
+      Dog.scan({and:[{'breed': {eq: 'unknown'}},{'breed':{eq:'Benji'}}]},function (err) {
+        should.exist(err);
+        err.code.should.eql('Invalid scan state; %s can only be used once');
       });
-    }).should.throw('Invalid scan state; %s can only be used once');
+    });
     done();
   });
 


### PR DESCRIPTION
Recently, there have been improvements on how validation errors have been handled, but I noticed that there were still a few cases that weren't handled: 

1. In `Model` there are calls to error throwing methods `Model.processCondition`, `Schema.parseDynamo`, `Schema.toDynamo`, and `Attribute.toDynamo` that aren't surrounded by `try/catch` with the error passed to the callback and promise.
2. `Query` and `Scan` building throw errors that need to be handled by the caller, even though there is an error mechanism in the callback or promise when `exec` is called.

Fixes:
- In `Model` I started by adding more `try/catch` statements at the call sites, but I realized that the logic could be simplified by doing `try/catch` statements at a higher level. So I added those and removed the others. 
- For `Query` and `Scan` building, I'm passing the first error encountered along so that it is sent to the callback and promise when `exec` is called.

Possible problems: 
- Passing an error along instead of throwing changes the stack trace when the error is handled. Since most users of this library probably don't care about the implementation details and just want to know what's wrong in the calling code, this shouldn't be much of an issue. 
- There is one thrown error that isn't handled, but it is when a model is initialized (see: https://github.com/automategreen/dynamoose/blob/master/lib/Model.js#L130), so there is no callback or promise mechanism. I assume that in this case, this is still the desired outcome.
