### PR TITLE
Issue 85 create required attributes on update

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -484,13 +484,6 @@ Scans a table. If callback is not provided, then a Scan object is returned. See 
 
 Updates and existing item in the table. Three types of updates: $PUT, $ADD, and $DELETE. Refer to DynamoDB's updateItem documentation for details on how PUT, ADD, and DELETE work.
 
-
-##### Options
-
-**allowEmptyArray**: boolean
-
-If true, the attribute can be updated to an empty array. If falsey, empty arrays will remove the attribute.  Defaults to false.
-
 **$PUT**
 
 Put is the default behavior.  The two example below are identical.
@@ -526,6 +519,16 @@ Dog.update({ownerId: 4, name: 'Odie'}, {$DELETE: {age: null}}, function (err) {
   console.log('Too old to keep count');
 })
 ```
+
+##### Options
+
+**allowEmptyArray**: boolean
+
+If true, the attribute can be updated to an empty array. If falsey, empty arrays will remove the attribute. Defaults to false.
+
+**createRequired**: boolean
+
+If true, required attributes will be filled with their default values on update (regardless of you specifying them for the update). Defaults to true.
 
 ### Query
 

--- a/Readme.md
+++ b/Readme.md
@@ -530,6 +530,10 @@ If true, the attribute can be updated to an empty array. If falsey, empty arrays
 
 If true, required attributes will be filled with their default values on update (regardless of you specifying them for the update). Defaults to true.
 
+**updateTimestamps**: boolean
+
+If true, the `timestamps` attributes will be updated. Will not do anything if timestamps attribute were not specified. Defaults to true.
+
 ### Query
 
 #### Model.query(query, options, callback)

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -31,7 +31,7 @@ function Attribute(schema, name, value) {
 
   this.attributes = {};
 
-  if ( this.type.name === 'map'){
+  if (this.type.name === 'map'){
 
     if(value.type) {
       value = value.map;

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -368,6 +368,11 @@ Model.update = function(NewModel, key, update, options, next) {
     options.createRequired = true;
   }
 
+  // default updateTimestamps to true
+  if (typeof options.updateTimestamps === 'undefined') {
+    options.updateTimestamps = true;
+  }
+
   var schema = NewModel.$__.schema;
 
   var hashKeyName = schema.hashKey.name;
@@ -570,10 +575,17 @@ Model.update = function(NewModel, key, update, options, next) {
 
   // update schema timestamps
   if (options.updateTimestamps && schema.timestamps) {
-    var createdAtAttribute = schema.attributes[schema.timestamps.createdAt];
-    var updatedAtAttribute = schema.attributes[schema.timestamps.updatedAt];
+    var createdAtLabel = schema.timestamps.createdAt;
+    var updatedAtLabel = schema.timestamps.updatedAt;
 
-    
+    var createdAtAttribute = schema.attributes[createdAtLabel];
+    var updatedAtAttribute = schema.attributes[updatedAtLabel];
+
+    var createdAtDefaultValue = createdAtAttribute.options.default(); 
+    var updatedAtDefaultValue = updatedAtAttribute.options.default();
+
+    operations.addConditionalSet(createdAtLabel, createdAtAttribute.toDynamo(createdAtDefaultValue));
+    operations.addSet(updatedAtLabel, updatedAtAttribute.toDynamo(updatedAtDefaultValue));
   }
 
   // do the required items check. Throw an error if you have an item that is required and
@@ -581,15 +593,19 @@ Model.update = function(NewModel, key, update, options, next) {
   if (options.createRequired) {
     for (var attributeName in schema.attributes) {
       var attribute = schema.attributes[attributeName];
-      if (attribute.required &&
-          attributeName !== schema.hashKey.name &&
-          (!schema.rangeKey || attributeName !== schema.rangeKey.name) &&
+      if (attribute.required && // if the attribute is required...
+          attributeName !== schema.hashKey.name && // ...and it isn't the hash key...
+          (!schema.rangeKey || attributeName !== schema.rangeKey.name) && // ...and it isn't the range key...
+          (!schema.timestamps || attributeName !== schema.timestamps.createdAt) && // ...and it isn't the createdAt attribute...
+          (!schema.timestamps || attributeName !== schema.timestamps.updatedAt) && // ...and it isn't the updatedAt attribute...
           !operations.SET[attributeName] &&
           !operations.ADD[attributeName] && 
           !operations.REMOVE[attributeName]) {
 
         var defaultValueOrFunction = attribute.options.default;
 
+        // throw an error if you have required attribute without a default (and you didn't supply 
+        //  anything to update with)
         if (typeof defaultValueOrFunction === 'undefined') {
           var err = 'Required attribute "' + attributeName + '" does not have a default.';
           debug('Error returned by updateItem', err);
@@ -599,11 +615,7 @@ Model.update = function(NewModel, key, update, options, next) {
 
         var defaultValue = typeof defaultValueOrFunction === 'function' ? defaultValueOrFunction() : defaultValueOrFunction;
 
-        if (schema.timestamps && attributeName === schema.timestamps.updatedAt) {
-          operations.addSet(attributeName, attribute.toDynamo(defaultValue));
-        } else {
-          operations.addConditionalSet(attributeName, attribute.toDynamo(defaultValue));
-        }
+        operations.addConditionalSet(attributeName, attribute.toDynamo(defaultValue));
       }
     }
   }

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -201,6 +201,7 @@ Model.prototype.put = function(options, next) {
   if(!options.overwrite) {
     item.ConditionExpression = 'attribute_not_exists(' + schema.hashKey.name + ')';
   }
+
   processCondition(item, options, this.$__.schema);
 
   debug('putItem', item);
@@ -219,14 +220,11 @@ Model.prototype.put = function(options, next) {
     return deferred.promise.nodeify(next);
   }
 
-
   if(model$.options.waitForActive) {
     return model$.table.waitForActive().then(put);
   }
 
   return put();
-
-
 };
 
 Model.prototype.save = Model.prototype.put;
@@ -311,7 +309,7 @@ Model.get = function(NewModel, key, options, next) {
         debug('Error returned by getItem', err);
         return deferred.reject(err);
       }
-      // console.log('RESP',JSON.stringify(data, null, 4));
+
       debug('getItem response', data);
 
       if(!Object.keys(data).length) {
@@ -342,167 +340,6 @@ Model.get = function(NewModel, key, options, next) {
   return deferred.promise.nodeify(next);
 };
 
-// Updates in Dynamoose
-//
-// old, still supported, syntax: (blank), $PUT, $ADD, $DELETE
-//     - ex) {a: 2, b: 3}, {$PUT: {a: 1, b: 7}}, {$ADD: {c}, $DELETE: {}, {a: 2, b: 3}}
-//
-// new, similar, syntax that more closely resembles DynamoDB: $SET, $ADD, $REMOVE, $DELETE
-//     $SET: the object keys are 'paths' and their values are 'operands'
-//     $REMOVE: array of paths to remove
-//     $ADD: keys are the 'paths' and their values are the 'values'
-//     $DELETE: keys are the 'paths' and their values are the 'values'
-
-function UpdateRequest() {
-  this.setItems = {};
-  this.addItems = {};
-  this.removeItems = [];
-  this.deleteItems = {};
-
-  this.createSetUpdateExpression = function () {
-    var updateExpression = 'SET';
-
-    Object.keys(this.setItems).map(function(key, index, allKeys) {
-      updateExpression += ' ' + 
-        key + 
-        "=" + 
-        (this.options.create_if_not_exists ? this.setItems[key] : 'if_not_exists(' + key + ', ' + this.setItems[key] + ')');
-
-      if (index !== allKeys.length()) updateExpression += ',';
-    });
-
-    return updateExpression;
-  }
-
-  this.createRemoveUpdateExpression = function () {
-    var updateExpression = 'REMOVE';
-
-    this.removeItems.map(function(path, index, allPaths) {
-      updateExpression += ' ' + path;
-      if (index !== allPaths.length()) updateExpression += ',';
-    });
-
-    return updateExpression;
-  }
-
-  this.createAddUpdateExpression = function () {
-    var updateExpression = 'ADD';
-
-    Object.keys(this.addItems).map(function(key, index, allKeys) {
-      updateExpression += ' ' + key + ' ' + this.addItems[key];
-      if (index !== allKeys.length()) updateExpression += ',';
-    });
-
-    return updateExpression;
-  }
-
-  this.createDeleteUpdateExpression = function () {
-    var updateExpression = 'DELETE';
-
-    Object.keys(this.deleteItems).map(function(key, index, allKeys) {
-      updateExpression += ' ' + key + ' ' + this.deleteItems[key];
-      if (index !== allKeys.length()) updateExpression += ',';
-    });
-
-    return updateExpression;
-  }
-
-  this.buildUpdateExpression = function () {
-    var updateExpression = (
-      this.createSetUpdateExpression() + ' ' +
-      this.createRemoveUpdateExpression() + ' ' +
-      this.createAddUpdateExpression() + ' ' +
-      this.createDeleteUpdateExpression()).trim();
-
-    console.dir(updateExpression);
-
-    return updateExpression;
-  }
-
-  this.processPuts = function (putUpdates) {
-    Object.keys(putUpdates).map(function(key, index, allKeys) {
-      var attribute = schema.attributes[key];
-      if (attribute) {
-        var value = putUpdates[key];
-
-        if ([null, undefined, ''].indexOf(value) !== -1 || 
-          (!options.allowEmptyArray && Array.isArray(value) && value.length === 0)) {
-          this.removeItems.push(key);
-        }
-
-        if (!this.setItems[key]) {
-          try {
-            this.setItems[key] = attribute.toDynamo(value);
-          } catch(error) {
-            deferred.reject(err);
-            return deferred.promise.nodeify(next);
-          }
-        }
-      }
-    });
-  } 
-
-  this.processSets = function (setUpdates) {
-    Object.keys(setUpdates).map(function(key, index, allKeys) {
-      var attribute = schema.attributes[key];
-      if (attribute && !this.setItems[key]) {
-        try {
-          this.setItems[key] = attribute.toDynamo(setUpdates[key]);
-        } catch(error) {
-          deferred.reject(err);
-          return deferred.promise.nodeify(next);
-        }
-      }
-    }
-  }
-
-  this.processAdds = function (addUpdates) {
-    Object.keys(addUpdates).map(function(key, index, allKeys) {
-      var attribute = schema.attributes[key];
-      if (attribute && !this.addItems[key]) {
-        try {
-          this.addItems[key] = attribute.toDynamo(addUpdates[key]);
-        } catch(error) {
-          deferred.reject(err);
-          return deferred.promise.nodeify(next);
-        }
-      }
-    }
-  }
-
-  this.processDeletes = function (deleteUpdates) {
-    Object.keys(deleteUpdates).map(function(key, index, allKeys) {
-      var attribute = schema.attributes[key];
-      if (attribute && !this.deleteItems[key]) {
-        try {
-          this.deleteItems[key] = attribute.toDynamo(deleteUpdates[key]);
-        } catch(error) {
-          deferred.reject(err);
-          return deferred.promise.nodeify(next);
-        }
-      }
-    }
-  }
-
-  this.processRemoves = function (removeUpdates) {
-    removeUpdates.map(function(removePath, index, allRemoves) {
-      if (schema.attributes[removePath] && this.removeItems.indexOf(removePath) === -1) this.removeItems.push(removePath);
-    }
-  }
-
-  this.processUpdateObject = function (updateObject) {
-    if (!updateObject.$PUT || !updateObject.$SET || !updateObject.$ADD || !updateObject.$REMOVE || !updateObject.$DELETE) {
-      this.processPuts(updateObject);
-    } else {
-      this.processPuts(updateObject.$PUT);
-      this.processSets(updateObject.$SET);
-      this.processAdds(updateObject.$ADD);
-      this.processDeletes(updateObject.$DELETE);
-      this.processRemoves(updateObject.$REMOVE);
-    }
-  }
-}
-
 /* NewModel.update({id: 123},
 // {
 //   $PUT: {a: 1, b: 2},
@@ -514,14 +351,21 @@ function UpdateRequest() {
 Model.update = function(NewModel, key, update, options, next) {
   debug('Update %j', key);
   var deferred = Q.defer();
+
   if(key === null || key === undefined) {
     deferred.reject(new errors.ModelError('Key required to get item'));
     return deferred.promise.nodeify(next);
   }
+
   options = options || {};
   if(typeof options === 'function') {
     next = options;
     options = {};
+  }
+
+  // default createRequired to true
+  if (typeof options.createRequired === 'undefined') {
+    options.createRequired = true;
   }
 
   var schema = NewModel.$__.schema;
@@ -537,7 +381,6 @@ Model.update = function(NewModel, key, update, options, next) {
     deferred.reject(new errors.ModelError('Range key required: ' + schema.rangeKey.name));
     return deferred.promise.nodeify(next);
   }
-
 
   var updateReq = {
     TableName: NewModel.$__.name,
@@ -560,110 +403,212 @@ Model.update = function(NewModel, key, update, options, next) {
     return deferred.promise.nodeify(next);
   }
 
-  
+  // determine the set of operations to be executed
+  function Operations() {
+    this.conditionalSet = {};
+    this.SET = {};
+    this.ADD = {};
+    this.REMOVE = {};
 
-  // // determine the set of operations to be executed
-  // var operations = {
-  //   SET: {},
-  //   ADD: {},
-  //   REMOVE: {}
-  // };
-  // if(update.$PUT || (!update.$PUT && !update.$DELETE && !update.$ADD)) {
-  //   var updatePUT = update;
-  //   if(update.$PUT) {
-  //     updatePUT = update.$PUT;
-  //   }
-  //   for(var putItem in updatePUT) {
-  //     var putAttr = schema.attributes[putItem];
-  //     if(putAttr) {
-  //       var val = updatePUT[putItem];
+    this.addConditionalSet = function(name, item) {
+      this.conditionalSet[name] = item;
+    };
 
-  //       var removeParams = val === null || val === undefined || val === '';
+    this.addSet = function(name, item) {
+      this.SET[name] = item;
+    };
 
-  //       if (!options.allowEmptyArray) {
-  //         removeParams = removeParams || (Array.isArray(val) && val.length === 0);
-  //       }
+    this.addAdd = function(name, item) {
+      this.ADD[name] = item;
+    };
 
-  //       if(removeParams) {
-  //         operations.REMOVE[putItem] = null;
-  //       } else {
-  //         try {
-  //           operations.SET[putItem] = putAttr.toDynamo(val);
-  //         } catch (err) {
-  //           deferred.reject(err);
-  //           return deferred.promise.nodeify(next);
-  //         }
-  //       }
-  //     }
-  //   }
-  // }
+    this.addRemove = function(name, item) {
+      this.REMOVE[name] = item;
+    };
 
-  // if(update.$DELETE) {
-  //   for(var deleteItem in update.$DELETE) {
-  //     var deleteAttr = schema.attributes[deleteItem];
-  //     if(deleteAttr) {
-  //       var delVal = update.$DELETE[deleteItem];
-  //       if(delVal !== null && delVal !== undefined) {
-  //         try {
-  //           operations.REMOVE[deleteItem] = deleteAttr.toDynamo(delVal);
-  //         } catch (err) {
-  //           deferred.reject(err);
-  //           return deferred.promise.nodeify(next);
-  //         }
-  //       } else {
-  //         operations.REMOVE[deleteItem] = null;
-  //       }
-  //     }
-  //   }
-  // }
+    this.getUpdateExpression = function(updateReq) {
+      var attrCount = 0;
+      var updateExpression = '';
 
-  // if(update.$ADD) {
-  //   for(var addItem in update.$ADD) {
-  //     var addAttr = schema.attributes[addItem];
-  //     if(addAttr) {
-  //       try {
-  //         operations.ADD[addItem] = addAttr.toDynamo(update.$ADD[addItem]);
-  //       } catch (err) {
-  //         deferred.reject(err);
-  //         return deferred.promise.nodeify(next);
-  //       }
-  //     }
-  //   }
-  // }
+      var attrName;
+      var valName;
+      var name;
+      var item;
 
-  // // construct the update expression
-  // //
-  // // we have to use update expressions because we are supporting
-  // // condition expressions, and you can't mix expressions with
-  // // non-expressions
-  // var attrCount = 0;
-  // updateReq.UpdateExpression = '';
-  // var first, k;
-  // for(var op in operations) {
-  //   if(Object.keys(operations[op]).length) {
-  //     if (updateReq.UpdateExpression) {
-  //       updateReq.UpdateExpression += ' ';
-  //     }
-  //     updateReq.UpdateExpression += op + ' ';
-  //     first = true;
-  //     for(k in operations[op]) {
-  //       if(first) {
-  //         first = false;
-  //       } else {
-  //         updateReq.UpdateExpression += ',';
-  //       }
-  //       var attrName = '#_n' + attrCount;
-  //       var valName = ':_p' + attrCount;
-  //       updateReq.UpdateExpression += attrName;
-  //       updateReq.ExpressionAttributeNames[attrName] = k;
-  //       if(operations[op][k]) {
-  //         updateReq.UpdateExpression += ' ' + (op === 'SET' ? '= ' : '') + valName;
-  //         updateReq.ExpressionAttributeValues[valName] = operations[op][k];
-  //       }
-  //       attrCount += 1;
-  //     }
-  //   }
-  // }
+      var setExpressions = [];
+      for (name in this.conditionalSet) {
+        item = this.conditionalSet[name];
+
+        attrName = '#_n' + attrCount;
+        valName = ':_p' + attrCount;
+
+        updateReq.ExpressionAttributeNames[attrName] = name;
+        updateReq.ExpressionAttributeValues[valName] = item;
+
+        setExpressions.push(attrName + ' = if_not_exists(' + attrName + ', ' + valName + ')');
+
+        attrCount += 1;
+      }
+
+      for (name in this.SET) {
+        item = this.SET[name];
+
+        attrName = '#_n' + attrCount;
+        valName = ':_p' + attrCount;
+
+        updateReq.ExpressionAttributeNames[attrName] = name;
+        updateReq.ExpressionAttributeValues[valName] = item;
+
+        setExpressions.push(attrName + ' = ' + valName);
+
+        attrCount += 1;
+      }
+      if (setExpressions.length > 0) {
+        updateExpression += 'SET ' + setExpressions.join(',') + ' ';
+      }
+
+      var addExpressions = [];
+      for (name in this.ADD) {
+        item = this.ADD[name];
+
+        attrName = '#_n' + attrCount;
+        valName = ':_p' + attrCount;
+
+        updateReq.ExpressionAttributeNames[attrName] = name;
+        updateReq.ExpressionAttributeValues[valName] = item;
+
+        addExpressions.push(attrName + ' ' + valName);
+
+        attrCount += 1;
+      }
+      if (addExpressions.length > 0) {
+        updateExpression += 'ADD ' + addExpressions.join(',') + ' ';
+      }
+
+      var removeExpressions = [];
+      for (name in this.REMOVE) {
+        item = this.REMOVE[name];
+
+        attrName = '#_n' + attrCount;
+
+        updateReq.ExpressionAttributeNames[attrName] = name;
+
+        removeExpressions.push(attrName);
+
+        attrCount += 1;
+      }
+      if (removeExpressions.length > 0) {
+        updateExpression += 'REMOVE ' + removeExpressions.join(',');
+      }
+
+      updateReq.UpdateExpression = updateExpression;
+    };
+  }
+
+  var operations = new Operations();
+
+  if (update.$PUT || (!update.$PUT && !update.$DELETE && !update.$ADD)) {
+    var updatePUT = update.$PUT || update;
+
+    for (var putItem in updatePUT) {
+      var putAttr = schema.attributes[putItem];
+      if (putAttr) {
+        var val = updatePUT[putItem];
+
+        var removeParams = val === null || val === undefined || val === '';
+
+        if (!options.allowEmptyArray) {
+          removeParams = removeParams || (Array.isArray(val) && val.length === 0);
+        }
+
+        if (removeParams) {
+          operations.addRemove(putItem, null);
+        } else {
+          try {
+            operations.addSet(putItem, putAttr.toDynamo(val));
+          } catch (err) {
+            deferred.reject(err);
+            return deferred.promise.nodeify(next);
+          }
+        }
+      }
+    }
+  }
+
+  if(update.$DELETE) {
+    for(var deleteItem in update.$DELETE) {
+      var deleteAttr = schema.attributes[deleteItem];
+      if(deleteAttr) {
+        var delVal = update.$DELETE[deleteItem];
+        if(delVal !== null && delVal !== undefined) {
+          try {
+            operations.addRemove(deleteItem, deleteAttr.toDynamo(delVal));
+          } catch (err) {
+            deferred.reject(err);
+            return deferred.promise.nodeify(next);
+          }
+        } else {
+          operations.addRemove(deleteItem, null);
+        }
+      }
+    }
+  }
+
+  if(update.$ADD) {
+    for(var addItem in update.$ADD) {
+      var addAttr = schema.attributes[addItem];
+      if(addAttr) {
+        try {
+          operations.addAdd(addItem, addAttr.toDynamo(update.$ADD[addItem]));
+        } catch (err) {
+          deferred.reject(err);
+          return deferred.promise.nodeify(next);
+        }
+      }
+    }
+  }
+
+  // update schema timestamps
+  if (options.updateTimestamps && schema.timestamps) {
+    var createdAtAttribute = schema.attributes[schema.timestamps.createdAt];
+    var updatedAtAttribute = schema.attributes[schema.timestamps.updatedAt];
+
+    
+  }
+
+  // do the required items check. Throw an error if you have an item that is required and
+  //  doesn't have a default.
+  if (options.createRequired) {
+    for (var attributeName in schema.attributes) {
+      var attribute = schema.attributes[attributeName];
+      if (attribute.required &&
+          attributeName !== schema.hashKey.name &&
+          (!schema.rangeKey || attributeName !== schema.rangeKey.name) &&
+          !operations.SET[attributeName] &&
+          !operations.ADD[attributeName] && 
+          !operations.REMOVE[attributeName]) {
+
+        var defaultValueOrFunction = attribute.options.default;
+
+        if (typeof defaultValueOrFunction === 'undefined') {
+          var err = 'Required attribute "' + attributeName + '" does not have a default.';
+          debug('Error returned by updateItem', err);
+          deferred.reject(err);
+          return deferred.promise.nodeify(next);
+        }
+
+        var defaultValue = typeof defaultValueOrFunction === 'function' ? defaultValueOrFunction() : defaultValueOrFunction;
+
+        if (schema.timestamps && attributeName === schema.timestamps.updatedAt) {
+          operations.addSet(attributeName, attribute.toDynamo(defaultValue));
+        } else {
+          operations.addConditionalSet(attributeName, attribute.toDynamo(defaultValue));
+        }
+      }
+    }
+  }
+
+  operations.getUpdateExpression(updateReq);
 
   // AWS doesn't allow empty expressions or attribute collections
   if(!updateReq.UpdateExpression) {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -342,6 +342,167 @@ Model.get = function(NewModel, key, options, next) {
   return deferred.promise.nodeify(next);
 };
 
+// Updates in Dynamoose
+//
+// old, still supported, syntax: (blank), $PUT, $ADD, $DELETE
+//     - ex) {a: 2, b: 3}, {$PUT: {a: 1, b: 7}}, {$ADD: {c}, $DELETE: {}, {a: 2, b: 3}}
+//
+// new, similar, syntax that more closely resembles DynamoDB: $SET, $ADD, $REMOVE, $DELETE
+//     $SET: the object keys are 'paths' and their values are 'operands'
+//     $REMOVE: array of paths to remove
+//     $ADD: keys are the 'paths' and their values are the 'values'
+//     $DELETE: keys are the 'paths' and their values are the 'values'
+
+function UpdateRequest() {
+  this.setItems = {};
+  this.addItems = {};
+  this.removeItems = [];
+  this.deleteItems = {};
+
+  this.createSetUpdateExpression = function () {
+    var updateExpression = 'SET';
+
+    Object.keys(this.setItems).map(function(key, index, allKeys) {
+      updateExpression += ' ' + 
+        key + 
+        "=" + 
+        (this.options.create_if_not_exists ? this.setItems[key] : 'if_not_exists(' + key + ', ' + this.setItems[key] + ')');
+
+      if (index !== allKeys.length()) updateExpression += ',';
+    });
+
+    return updateExpression;
+  }
+
+  this.createRemoveUpdateExpression = function () {
+    var updateExpression = 'REMOVE';
+
+    this.removeItems.map(function(path, index, allPaths) {
+      updateExpression += ' ' + path;
+      if (index !== allPaths.length()) updateExpression += ',';
+    });
+
+    return updateExpression;
+  }
+
+  this.createAddUpdateExpression = function () {
+    var updateExpression = 'ADD';
+
+    Object.keys(this.addItems).map(function(key, index, allKeys) {
+      updateExpression += ' ' + key + ' ' + this.addItems[key];
+      if (index !== allKeys.length()) updateExpression += ',';
+    });
+
+    return updateExpression;
+  }
+
+  this.createDeleteUpdateExpression = function () {
+    var updateExpression = 'DELETE';
+
+    Object.keys(this.deleteItems).map(function(key, index, allKeys) {
+      updateExpression += ' ' + key + ' ' + this.deleteItems[key];
+      if (index !== allKeys.length()) updateExpression += ',';
+    });
+
+    return updateExpression;
+  }
+
+  this.buildUpdateExpression = function () {
+    var updateExpression = (
+      this.createSetUpdateExpression() + ' ' +
+      this.createRemoveUpdateExpression() + ' ' +
+      this.createAddUpdateExpression() + ' ' +
+      this.createDeleteUpdateExpression()).trim();
+
+    console.dir(updateExpression);
+
+    return updateExpression;
+  }
+
+  this.processPuts = function (putUpdates) {
+    Object.keys(putUpdates).map(function(key, index, allKeys) {
+      var attribute = schema.attributes[key];
+      if (attribute) {
+        var value = putUpdates[key];
+
+        if ([null, undefined, ''].indexOf(value) !== -1 || 
+          (!options.allowEmptyArray && Array.isArray(value) && value.length === 0)) {
+          this.removeItems.push(key);
+        }
+
+        if (!this.setItems[key]) {
+          try {
+            this.setItems[key] = attribute.toDynamo(value);
+          } catch(error) {
+            deferred.reject(err);
+            return deferred.promise.nodeify(next);
+          }
+        }
+      }
+    });
+  } 
+
+  this.processSets = function (setUpdates) {
+    Object.keys(setUpdates).map(function(key, index, allKeys) {
+      var attribute = schema.attributes[key];
+      if (attribute && !this.setItems[key]) {
+        try {
+          this.setItems[key] = attribute.toDynamo(setUpdates[key]);
+        } catch(error) {
+          deferred.reject(err);
+          return deferred.promise.nodeify(next);
+        }
+      }
+    }
+  }
+
+  this.processAdds = function (addUpdates) {
+    Object.keys(addUpdates).map(function(key, index, allKeys) {
+      var attribute = schema.attributes[key];
+      if (attribute && !this.addItems[key]) {
+        try {
+          this.addItems[key] = attribute.toDynamo(addUpdates[key]);
+        } catch(error) {
+          deferred.reject(err);
+          return deferred.promise.nodeify(next);
+        }
+      }
+    }
+  }
+
+  this.processDeletes = function (deleteUpdates) {
+    Object.keys(deleteUpdates).map(function(key, index, allKeys) {
+      var attribute = schema.attributes[key];
+      if (attribute && !this.deleteItems[key]) {
+        try {
+          this.deleteItems[key] = attribute.toDynamo(deleteUpdates[key]);
+        } catch(error) {
+          deferred.reject(err);
+          return deferred.promise.nodeify(next);
+        }
+      }
+    }
+  }
+
+  this.processRemoves = function (removeUpdates) {
+    removeUpdates.map(function(removePath, index, allRemoves) {
+      if (schema.attributes[removePath] && this.removeItems.indexOf(removePath) === -1) this.removeItems.push(removePath);
+    }
+  }
+
+  this.processUpdateObject = function (updateObject) {
+    if (!updateObject.$PUT || !updateObject.$SET || !updateObject.$ADD || !updateObject.$REMOVE || !updateObject.$DELETE) {
+      this.processPuts(updateObject);
+    } else {
+      this.processPuts(updateObject.$PUT);
+      this.processSets(updateObject.$SET);
+      this.processAdds(updateObject.$ADD);
+      this.processDeletes(updateObject.$DELETE);
+      this.processRemoves(updateObject.$REMOVE);
+    }
+  }
+}
+
 /* NewModel.update({id: 123},
 // {
 //   $PUT: {a: 1, b: 2},
@@ -399,108 +560,110 @@ Model.update = function(NewModel, key, update, options, next) {
     return deferred.promise.nodeify(next);
   }
 
-  // determine the set of operations to be executed
-  var operations = {
-    SET: {},
-    ADD: {},
-    REMOVE: {}
-  };
-  if(update.$PUT || (!update.$PUT && !update.$DELETE && !update.$ADD)) {
-    var updatePUT = update;
-    if(update.$PUT) {
-      updatePUT = update.$PUT;
-    }
-    for(var putItem in updatePUT) {
-      var putAttr = schema.attributes[putItem];
-      if(putAttr) {
-        var val = updatePUT[putItem];
+  
 
-        var removeParams = val === null || val === undefined || val === '';
+  // // determine the set of operations to be executed
+  // var operations = {
+  //   SET: {},
+  //   ADD: {},
+  //   REMOVE: {}
+  // };
+  // if(update.$PUT || (!update.$PUT && !update.$DELETE && !update.$ADD)) {
+  //   var updatePUT = update;
+  //   if(update.$PUT) {
+  //     updatePUT = update.$PUT;
+  //   }
+  //   for(var putItem in updatePUT) {
+  //     var putAttr = schema.attributes[putItem];
+  //     if(putAttr) {
+  //       var val = updatePUT[putItem];
 
-        if (!options.allowEmptyArray) {
-          removeParams = removeParams || (Array.isArray(val) && val.length === 0);
-        }
+  //       var removeParams = val === null || val === undefined || val === '';
 
-        if(removeParams) {
-          operations.REMOVE[putItem] = null;
-        } else {
-          try {
-            operations.SET[putItem] = putAttr.toDynamo(val);
-          } catch (err) {
-            deferred.reject(err);
-            return deferred.promise.nodeify(next);
-          }
-        }
-      }
-    }
-  }
+  //       if (!options.allowEmptyArray) {
+  //         removeParams = removeParams || (Array.isArray(val) && val.length === 0);
+  //       }
 
-  if(update.$DELETE) {
-    for(var deleteItem in update.$DELETE) {
-      var deleteAttr = schema.attributes[deleteItem];
-      if(deleteAttr) {
-        var delVal = update.$DELETE[deleteItem];
-        if(delVal !== null && delVal !== undefined) {
-          try {
-            operations.REMOVE[deleteItem] = deleteAttr.toDynamo(delVal);
-          } catch (err) {
-            deferred.reject(err);
-            return deferred.promise.nodeify(next);
-          }
-        } else {
-          operations.REMOVE[deleteItem] = null;
-        }
-      }
-    }
-  }
+  //       if(removeParams) {
+  //         operations.REMOVE[putItem] = null;
+  //       } else {
+  //         try {
+  //           operations.SET[putItem] = putAttr.toDynamo(val);
+  //         } catch (err) {
+  //           deferred.reject(err);
+  //           return deferred.promise.nodeify(next);
+  //         }
+  //       }
+  //     }
+  //   }
+  // }
 
-  if(update.$ADD) {
-    for(var addItem in update.$ADD) {
-      var addAttr = schema.attributes[addItem];
-      if(addAttr) {
-        try {
-          operations.ADD[addItem] = addAttr.toDynamo(update.$ADD[addItem]);
-        } catch (err) {
-          deferred.reject(err);
-          return deferred.promise.nodeify(next);
-        }
-      }
-    }
-  }
+  // if(update.$DELETE) {
+  //   for(var deleteItem in update.$DELETE) {
+  //     var deleteAttr = schema.attributes[deleteItem];
+  //     if(deleteAttr) {
+  //       var delVal = update.$DELETE[deleteItem];
+  //       if(delVal !== null && delVal !== undefined) {
+  //         try {
+  //           operations.REMOVE[deleteItem] = deleteAttr.toDynamo(delVal);
+  //         } catch (err) {
+  //           deferred.reject(err);
+  //           return deferred.promise.nodeify(next);
+  //         }
+  //       } else {
+  //         operations.REMOVE[deleteItem] = null;
+  //       }
+  //     }
+  //   }
+  // }
 
-  // construct the update expression
-  //
-  // we have to use update expressions because we are supporting
-  // condition expressions, and you can't mix expressions with
-  // non-expressions
-  var attrCount = 0;
-  updateReq.UpdateExpression = '';
-  var first, k;
-  for(var op in operations) {
-    if(Object.keys(operations[op]).length) {
-      if (updateReq.UpdateExpression) {
-        updateReq.UpdateExpression += ' ';
-      }
-      updateReq.UpdateExpression += op + ' ';
-      first = true;
-      for(k in operations[op]) {
-        if(first) {
-          first = false;
-        } else {
-          updateReq.UpdateExpression += ',';
-        }
-        var attrName = '#_n' + attrCount;
-        var valName = ':_p' + attrCount;
-        updateReq.UpdateExpression += attrName;
-        updateReq.ExpressionAttributeNames[attrName] = k;
-        if(operations[op][k]) {
-          updateReq.UpdateExpression += ' ' + (op === 'SET' ? '= ' : '') + valName;
-          updateReq.ExpressionAttributeValues[valName] = operations[op][k];
-        }
-        attrCount += 1;
-      }
-    }
-  }
+  // if(update.$ADD) {
+  //   for(var addItem in update.$ADD) {
+  //     var addAttr = schema.attributes[addItem];
+  //     if(addAttr) {
+  //       try {
+  //         operations.ADD[addItem] = addAttr.toDynamo(update.$ADD[addItem]);
+  //       } catch (err) {
+  //         deferred.reject(err);
+  //         return deferred.promise.nodeify(next);
+  //       }
+  //     }
+  //   }
+  // }
+
+  // // construct the update expression
+  // //
+  // // we have to use update expressions because we are supporting
+  // // condition expressions, and you can't mix expressions with
+  // // non-expressions
+  // var attrCount = 0;
+  // updateReq.UpdateExpression = '';
+  // var first, k;
+  // for(var op in operations) {
+  //   if(Object.keys(operations[op]).length) {
+  //     if (updateReq.UpdateExpression) {
+  //       updateReq.UpdateExpression += ' ';
+  //     }
+  //     updateReq.UpdateExpression += op + ' ';
+  //     first = true;
+  //     for(k in operations[op]) {
+  //       if(first) {
+  //         first = false;
+  //       } else {
+  //         updateReq.UpdateExpression += ',';
+  //       }
+  //       var attrName = '#_n' + attrCount;
+  //       var valName = ':_p' + attrCount;
+  //       updateReq.UpdateExpression += attrName;
+  //       updateReq.ExpressionAttributeNames[attrName] = k;
+  //       if(operations[op][k]) {
+  //         updateReq.UpdateExpression += ' ' + (op === 'SET' ? '= ' : '') + valName;
+  //         updateReq.ExpressionAttributeValues[valName] = operations[op][k];
+  //       }
+  //       attrCount += 1;
+  //     }
+  //   }
+  // }
 
   // AWS doesn't allow empty expressions or attribute collections
   if(!updateReq.UpdateExpression) {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -351,11 +351,7 @@ Model.get = function(NewModel, key, options, next) {
 Model.update = function(NewModel, key, update, options, next) {
   debug('Update %j', key);
   var deferred = Q.defer();
-
-  if(key === null || key === undefined) {
-    deferred.reject(new errors.ModelError('Key required to get item'));
-    return deferred.promise.nodeify(next);
-  }
+  var schema = NewModel.$__.schema;
 
   options = options || {};
   if(typeof options === 'function') {
@@ -373,18 +369,38 @@ Model.update = function(NewModel, key, update, options, next) {
     options.updateTimestamps = true;
   }
 
-  var schema = NewModel.$__.schema;
+  // if the key part was emtpy, try the key defaults before giving up...
+  if (key === null || key === undefined) {
+    key = {};
+
+    // first figure out the primary/hash key
+    var hashKeyDefault = schema.attributes[schema.hashKey.name].options.default;
+
+    if (typeof hashKeyDefault === 'undefined') {
+      deferred.reject(new errors.ModelError('Key required to get item'));
+      return deferred.promise.nodeify(next);
+    }
+
+    key[schema.hashKey.name] = typeof hashKeyDefault === 'function' ? hashKeyDefault() : hashKeyDefault;
+
+    // now see if you have to figure out a range key
+    if (schema.rangeKey) {
+      var rangeKeyDefault = schema.attributes[schema.rangeKey.name].options.default;
+
+      if (typeof rangeKeyDefault === 'undefined') {
+        deferred.reject(new errors.ModelError('Range key required: ' + schema.rangeKey.name));
+        return deferred.promise.nodeify(next);
+      }
+
+      key[schema.rangeKey.name] = typeof rangeKeyDefault === 'function' ? rangeKeyDefault() : rangeKeyDefault;
+    }
+  }
 
   var hashKeyName = schema.hashKey.name;
   if(!key[hashKeyName]) {
     var keyVal = key;
     key = {};
     key[hashKeyName] = keyVal;
-  }
-
-  if(schema.rangeKey && !key[schema.rangeKey.name]) {
-    deferred.reject(new errors.ModelError('Range key required: ' + schema.rangeKey.name));
-    return deferred.promise.nodeify(next);
   }
 
   var updateReq = {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -426,13 +426,13 @@ Model.update = function(NewModel, key, update, options, next) {
 
   // determine the set of operations to be executed
   function Operations() {
-    this.conditionalSet = {};
+    this.ifNotExistsSet = {};
     this.SET = {};
     this.ADD = {};
     this.REMOVE = {};
 
-    this.addConditionalSet = function(name, item) {
-      this.conditionalSet[name] = item;
+    this.addIfNotExistsSet = function(name, item) {
+      this.ifNotExistsSet[name] = item;
     };
 
     this.addSet = function(name, item) {
@@ -457,8 +457,8 @@ Model.update = function(NewModel, key, update, options, next) {
       var item;
 
       var setExpressions = [];
-      for (name in this.conditionalSet) {
-        item = this.conditionalSet[name];
+      for (name in this.ifNotExistsSet) {
+        item = this.ifNotExistsSet[name];
 
         attrName = '#_n' + attrCount;
         valName = ':_p' + attrCount;
@@ -597,10 +597,10 @@ Model.update = function(NewModel, key, update, options, next) {
     var createdAtAttribute = schema.attributes[createdAtLabel];
     var updatedAtAttribute = schema.attributes[updatedAtLabel];
 
-    var createdAtDefaultValue = createdAtAttribute.options.default(); 
+    var createdAtDefaultValue = createdAtAttribute.options.default();
     var updatedAtDefaultValue = updatedAtAttribute.options.default();
 
-    operations.addConditionalSet(createdAtLabel, createdAtAttribute.toDynamo(createdAtDefaultValue));
+    operations.addIfNotExistsSet(createdAtLabel, createdAtAttribute.toDynamo(createdAtDefaultValue));
     operations.addSet(updatedAtLabel, updatedAtAttribute.toDynamo(updatedAtDefaultValue));
   }
 
@@ -631,7 +631,7 @@ Model.update = function(NewModel, key, update, options, next) {
 
         var defaultValue = typeof defaultValueOrFunction === 'function' ? defaultValueOrFunction() : defaultValueOrFunction;
 
-        operations.addConditionalSet(attributeName, attribute.toDynamo(defaultValue));
+        operations.addIfNotExistsSet(attributeName, attribute.toDynamo(defaultValue));
       }
     }
   }

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -221,5 +221,4 @@ Schema.prototype.virtualpath = function (name) {
   return this.virtuals[name];
 };
 
-
 module.exports = Schema;

--- a/test/Model.js
+++ b/test/Model.js
@@ -68,7 +68,8 @@ describe('Model', function (){
     {
       id: {
         type:  Number,
-        validate: function (v) { return v > 0; }
+        validate: function (v) { return v > 0; },
+        default: 888
       },
       name: {
         type: String,
@@ -535,6 +536,69 @@ describe('Model', function (){
           oliver.name.should.eql('Oliver');
           should.not.exist(oliver.owner);
           should.not.exist(oliver.age);
+          done();
+        });
+      });
+    });
+
+    it("If key is null or undefined, will use defaults", function (done) {
+      Cat3.update(null, {age: 3, name: 'Furrgie'}, function (err, data) {
+        should.not.exist(err);
+        should.exist(data);
+        data.id.should.eql(888);
+        data.name.should.equal('Furrgie');
+        data.age.should.equal(3);
+
+        Cat3.get(888, function (err, furrgie) {
+          should.not.exist(err);
+          should.exist(furrgie);
+          furrgie.id.should.eql(888);
+          furrgie.name.should.eql('Furrgie');
+          data.age.should.equal(3);
+
+          Cat3.update(undefined, {age: 4}, function (err, data) {
+            should.not.exist(err);
+            should.exist(data);
+            data.id.should.eql(888);
+            data.name.should.equal('Furrgie');
+            data.age.should.equal(4);
+
+            Cat3.get(888, function (err, furrgie) {
+              should.not.exist(err);
+              should.exist(furrgie);
+              furrgie.id.should.eql(888);
+              furrgie.name.should.eql('Furrgie');
+              should.not.exist(furrgie.owner);
+              data.age.should.equal(4);
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it("If key is null or undefined and default isn't provided, will throw an error", function (done) {
+      Cat.update(null, {name: 'Oliver'}, function (err, data) {
+        should.not.exist(data);
+        should.exist(err);
+        done();
+      });
+    });
+
+    it("If key is a value, will search by that value", function (done) {
+      Cat3.update(888, {age: 5}, function (err, data) {
+        should.not.exist(err);
+        should.exist(data);
+        data.id.should.eql(888);
+        data.name.should.equal('Furrgie');
+        data.age.should.equal(5);
+
+        Cat3.get(888, function (err, furrgie) {
+          should.not.exist(err);
+          should.exist(furrgie);
+          furrgie.id.should.eql(888);
+          furrgie.name.should.eql('Furrgie');
+          data.age.should.equal(5);
           done();
         });
       });

--- a/test/Model.js
+++ b/test/Model.js
@@ -12,7 +12,7 @@ dynamoose.local();
 
 var should = require('should');
 
-var Cat, Cat2, Cat3;
+var Cat, Cat2, Cat3, Cat4;
 
 describe('Model', function (){
   this.timeout(5000);
@@ -594,36 +594,17 @@ describe('Model', function (){
     });
 
     it('Does not add required attributes if createRequired is false', function (done) {
-      Cat3.update({id: 24}, {name: 'Grumpy'}, {createRequired: false}, function (err, data) {
+      Cat3.update({id: 24}, {name: 'Cat-rina'}, {createRequired: false}, function (err, data) {
         should.not.exist(err);
         should.exist(data);
         data.id.should.eql(24);
-        data.name.should.equal('Grumpy');
+        data.name.should.equal('Cat-rina');
         should.not.exist(data.age);
         Cat3.get(24, function (err, mittens) {
           should.not.exist(err);
           should.exist(mittens);
           mittens.id.should.eql(24);
-          data.name.should.equal('Grumpy');
-          should.not.exist(data.age);
-          should.not.exist(mittens.owner);
-          done();
-        });
-      });
-    });
-
-    it('UpdatedAt will be updated', function (done) {
-      Cat4.update({id: 22}, {name: 'Pawmeranian'}, function (err, data) {
-        should.not.exist(err);
-        should.exist(data);
-        data.id.should.eql(24);
-        data.name.should.equal('Grumpy');
-        should.not.exist(data.age);
-        Cat4.get(24, function (err, mittens) {
-          should.not.exist(err);
-          should.exist(mittens);
-          mittens.id.should.eql(24);
-          data.name.should.equal('Grumpy');
+          data.name.should.equal('Cat-rina');
           should.not.exist(data.age);
           should.not.exist(mittens.owner);
           done();
@@ -632,22 +613,58 @@ describe('Model', function (){
     });
 
     it('If item did not exist and timestamps are desired, createdAt and updatedAt will both be filled in', function (done) {
-      // Cat3.update({id: 24}, {name: 'Grumpy'}, {createRequired: false}, function (err, data) {
-      //   should.not.exist(err);
-      //   should.exist(data);
-      //   data.id.should.eql(24);
-      //   data.name.should.equal('Grumpy');
-      //   should.not.exist(data.age);
-      //   Cat3.get(24, function (err, mittens) {
-      //     should.not.exist(err);
-      //     should.exist(mittens);
-      //     mittens.id.should.eql(24);
-      //     data.name.should.equal('Grumpy');
-      //     should.not.exist(data.age);
-      //     should.not.exist(mittens.owner);
-      //     done();
-      //   });
-      // });
+      // try a delete beforehand in case the test is run more than once
+      Cat4.delete({id: 22}, function () {
+        Cat4.update({id: 22}, {name: 'Twinkles'}, function (err, data) {
+          should.not.exist(err);
+          should.exist(data);
+          should.exist(data.myLittleCreatedAt);
+          should.exist(data.myLittleUpdatedAt);
+          data.id.should.eql(22);
+          data.name.should.equal('Twinkles');
+
+          Cat4.get(22, function (err, twinkles) {
+            should.not.exist(err);
+            should.exist(twinkles);
+            twinkles.id.should.eql(22);
+            twinkles.name.should.equal('Twinkles');
+            should.exist(twinkles.myLittleCreatedAt);
+            should.exist(twinkles.myLittleUpdatedAt);
+            done();
+          });
+        });
+      });
+    });
+
+    it('UpdatedAt will be updated ', function (done) {
+      // try a delete beforehand in case the test is run more than once
+      Cat4.delete({id: 22}, function () {
+        Cat4.update({id: 22}, {name: 'Twinkles'}, function (err, data) {
+          should.not.exist(err);
+          should.exist(data);
+          data.id.should.eql(22);
+          data.name.should.equal('Twinkles');
+          should.exist(data.myLittleCreatedAt);
+          should.exist(data.myLittleUpdatedAt);
+
+          // now do another update
+          Cat4.update({id: 22}, {name: 'Furr-nando'}, function (err, data) {
+            should.not.exist(err);
+            should.exist(data);
+            data.id.should.eql(22);
+            data.name.should.equal('Furr-nando');
+            data.myLittleUpdatedAt.getTime().should.be.above(data.myLittleCreatedAt.getTime());
+            Cat4.get(22, function (err, furrnando) {
+              should.not.exist(err);
+              should.exist(furrnando);
+              furrnando.id.should.eql(22);
+              furrnando.name.should.equal('Furr-nando');
+              furrnando.myLittleUpdatedAt.getTime().should.be.above(furrnando.myLittleCreatedAt.getTime());
+              done();
+            });
+          });
+        });
+      });
     });
 
     it('Default puts attribute', function (done) {


### PR DESCRIPTION
This pull request is meant to address Issue #85. There is a lot going on here...

`Model.update` now has a new touch. If you pass a `null` or `undefined` key, then there is a check for key defaults. If the key attributes have defaults, those will be used. If they don't, _then_ an error is thrown. This check is currently not in place.

`timestamps` (as defined in the schema) are now updated by default. You can turn this behaviour off by:

1. Not having `timestamps`
2. setting the `updateTimestamps` option to `false`

But, most importantly, this PR now has the update _also_ conditionally update required attributes. There is one catch though: **required attributes that do not have a default value will throw an error on update if no value is provided for them**. 

I also added some tests for `Module.update`