### PR TITLE
Fix bug when `next` callback is null

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -188,7 +188,9 @@ function sendErrorToCallback(error, options, next) {
   if(typeof options === 'function') {
     next = options;
   }
-  next(error);
+  if(typeof next === 'function') {
+    next(error);
+  }
 }
 
 


### PR DESCRIPTION
Missed a bug that occurs when promises are used. 

The tests don't have any tests for promises. I will add some in a future PR.