### PR TITLE
Add support for native boolean values

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -215,6 +215,8 @@ The following table describes valid Attribute Types, and their translation to Dy
 | [Object]       | 'SS'                    |
 | [Array]        | 'SS'                    |
 
+_**: Use the useNativeBooleans flag to store Boolean values as 'BOOL'_
+
 ### Attribute Definitions
 
 Attribute definitions define constraints on a particular attribute specified in a Schema. Attribute definitions may be an object type (see [Attribute Types](#attribute-types)) or an object with the following options:
@@ -244,6 +246,7 @@ Defines the attribute as a local or global secondary index. Index can either be 
 - _rangeKey: 'string'_ - The range key for a global secondary index.
 - _project: boolean | ['string', ...]_ - Sets the attributes to be projected for the index.  `true` projects all attributes, `false` projects only the key attributes, and ['string', ...] projects the attributes listed. Default is `true`.
 - _throughput: number | {read: number, write: number}_ - Sets the throughput for the global secondary index.
+- _useNativeBooleans: boolean_ - Later versions of Dynamo added support for Boolean attributes. Set to true to add support for Boolean values that aren't stored as strings.
 
 **default**: function | value
 

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -29,6 +29,13 @@ function Attribute(schema, name, value) {
     }
   }
 
+  if (schema.useNativeBooleans) {
+    if(this.type.name === 'boolean') {
+      debug('Overwriting attribute %s type to be a native boolean', name);
+      this.type = this.types.nativeBoolean;
+    }
+  }
+
   this.attributes = {};
 
   if (this.type.name === 'map'){
@@ -100,6 +107,10 @@ Attribute.prototype.types = {
     name: 'boolean',
     dynamo: 'S',
     dynamofy: JSON.stringify
+  },
+  nativeBoolean: {
+    name: 'boolean',
+    dynamo: 'BOOL'
   },
   date: {
     name: 'date',
@@ -464,7 +475,8 @@ Attribute.prototype.parseDynamo = function(json) {
       val = dedynamofy('N', this.isSet, json, JSON.parse);
       break;
     case 'boolean':
-      val = dedynamofy('S', this.isSet, json, JSON.parse);
+      // 'S' is backwards compatible however 'BOOL' is a new valid argument
+      val = dedynamofy(this.type.dynamo, this.isSet, json, JSON.parse);
       break;
     case 'date':
       val = dedynamofy('N', this.isSet, json, datify);

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -61,6 +61,7 @@ function Schema(obj, options) {
   }
 
   this.useDocumentTypes = !!this.options.useDocumentTypes;
+  this.useNativeBooleans = !!this.options.useNativeBooleans;
 
   this.attributes = {};
   this.indexes = {local: {}, global: {}};

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -333,6 +333,29 @@ describe('Schema tests', function (){
     done();
   });
 
+  it('Schema with use Native Booleans', function (done) {
+    var schema = new Schema({
+     name: String,
+     isAwesome: Boolean
+    }, {useNativeBooleans: true});
+
+    var Cat = dynamoose.model('Cat', schema);
+    var fluffy = new Cat();
+
+    fluffy.name = 'Fluff Johnson';
+    fluffy.isAwesome = true;
+
+    schema.useNativeBooleans.should.be.ok;
+
+    Cat.$__.schema.attributes.isAwesome.type.dynamo.should.eql('BOOL');
+
+    Cat.$__.table.delete(function () {
+      delete dynamoose.models.Cat;
+      done();
+    });
+
+  });
+
   it('Schema with secondary indexes', function (done) {
     var schema = new Schema({
       ownerId: {


### PR DESCRIPTION
Newer versions of dynamo support boolean values. This library currently interprets boolean values as strings and stores them as 'S'. This pull request provides the ability to add a 'useNativeBooleans' property to the Schema, which will provide an override and stores these values as 'BOOL' instead.