### PR TITLE
fix Attribute.prototype.toDynamo method to support Native Booleans

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -374,7 +374,10 @@ Attribute.prototype.toDynamo = function(val, noSet, model) {
       val = type.dynamofy(val);
     }
 
-    val = val.toString();
+    if(type.dynamo !== 'BOOL') {
+      val = val.toString();
+    }
+
     if(type.dynamo === 'S') {
       if(this.options.trim) {
         val = val.trim();


### PR DESCRIPTION
Hi, just saw that the native booleans have been added, but it was missing a check when "dynamofying" the attribute. So here is a quick fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/automategreen/dynamoose/109)
<!-- Reviewable:end -->
