### PR TITLE
Fix critical bug with deleting and creating global secondary index

### DIFF
--- a/lib/Table.js
+++ b/lib/Table.js
@@ -38,11 +38,8 @@ var compareIndexes = function compareIndexes(local, remote) {
       if (remoteIndexes[j].IndexName === localIndexes[i].IndexName) {
         // let's see if the core data matches. if it doesn't,
         // we may need to delete the remote GSI and rebuild.
-        var localIndex = _.pick(localIndexes[i], 'IndexName', 'KeySchema', 'Projection', 'ProvisionedThroughput');
-        var remoteIndex = _.pick(remoteIndexes[j], 'IndexName', 'KeySchema', 'Projection', 'ProvisionedThroughput');
-        if (remoteIndex.hasOwnProperty('ProvisionedThroughput')) {
-          delete remoteIndex.ProvisionedThroughput.NumberOfDecreasesToday;
-        }
+        var localIndex = _.pick(localIndexes[i], 'IndexName', 'KeySchema', 'Projection');
+        var remoteIndex = _.pick(remoteIndexes[j], 'IndexName', 'KeySchema', 'Projection');
 
         if (!_.isEqual(remoteIndex, localIndex)) {
           indexes.both.push(localIndex);


### PR DESCRIPTION
Dynamoose previously removed index and tried to create new. But that time was more than timeout and it's crashed app.
We shouldn't set ProvisionedThroughput to previous value after new code deploy.
ProvisionedThroughput is the dynamic value that can be managed with auto scaling script.