### PR TITLE
Support GSI with same hashkey as Table

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -586,6 +586,16 @@ Dog.query({breed: {eq: 'Beagle'} }, function (err, dogs) {
 });
 ```
 
+#### query.using(indexName)
+
+Tells the query to use a particular index.  This is necessary when there are multiple indexes defined on the hashkey attribute of the table, otherwise it will default to using the first index in the list.
+
+```js
+Dog.query('ownerId').using('BreedRangeIndex').eq(20).where('breed').beginsWith('S').exec(function (err, dogs) {
+  // Look at all the breeds that start with S for owner 20 
+});
+```
+
 #### query.exec(callback)
 
 Executes the query against the table or index.

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -87,7 +87,7 @@ Query.prototype.exec = function (next) {
   // the hash and range key on the primary table.  If they don't match then we
   // can look for a secondary index to query.
   if(schema.hashKey.name !== this.query.hashKey.name ||
-    (this.query.rangeKey && schema.rangeKey.name !== this.query.rangeKey.name)) {
+    (this.query.rangeKey && schema.rangeKey && schema.rangeKey.name !== this.query.rangeKey.name)) {
     debug('query is on global secondary index');
     for(indexName in schema.indexes.global) {
       index = schema.indexes.global[indexName];

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -83,7 +83,11 @@ Query.prototype.exec = function (next) {
   };
 
   var indexName, index;
-  if(schema.hashKey.name !== this.query.hashKey.name) {
+  // Check both hash key and range key in the query to see if they do not match
+  // the hash and range key on the primary table.  If they don't match then we
+  // can look for a secondary index to query.
+  if(schema.hashKey.name !== this.query.hashKey.name ||
+    (this.query.rangeKey && schema.rangeKey.name !== this.query.rangeKey.name)) {
     debug('query is on global secondary index');
     for(indexName in schema.indexes.global) {
       index = schema.indexes.global[indexName];
@@ -93,7 +97,6 @@ Query.prototype.exec = function (next) {
         break;
       }
     }
-
   }
 
   var hashAttr = schema.attributes[this.query.hashKey.name];
@@ -136,6 +139,13 @@ Query.prototype.exec = function (next) {
         );
       }
     }
+  }
+
+  // if the index name has been explicitly set via the api then let that override
+  // anything that has been previously derived
+  if(this.options.indexName){
+    debug('forcing index: %s', this.options.indexName);
+    queryReq.IndexName = this.options.indexName;
   }
 
 
@@ -498,6 +508,11 @@ Query.prototype.count = function () {
 Query.prototype.counts = function () {
   this.options.counts = true;
   this.options.select = 'COUNT';
+  return this;
+};
+
+Query.prototype.using = function (indexName) {
+  this.options.indexName = indexName;
   return this;
 };
 

--- a/test/Model.js
+++ b/test/Model.js
@@ -15,7 +15,7 @@ var should = require('should');
 var Cat, Cat2, Cat3, Cat4;
 
 describe('Model', function (){
-  this.timeout(5000);
+  this.timeout(15000);
 
 
   before(function(done) {

--- a/test/Query.js
+++ b/test/Query.js
@@ -26,7 +26,18 @@ describe('Query', function (){
       ownerId: {
         type: Number,
         validate: function(v) { return v > 0; },
-        hashKey: true
+        hashKey: true,
+        index: [{
+          global: true,
+          rangeKey: 'color',
+          name: 'ColorRangeIndex',
+          project: true, // ProjectionType: ALL
+        },{
+          global: true,
+          rangeKey: 'breed',
+          name: 'BreedRangeIndex',
+          project: true, // ProjectionType: ALL
+        }]
       },
       breed: {
         type: String,
@@ -91,7 +102,11 @@ describe('Query', function (){
       {ownerId:16, name: 'Marley', breed: 'Labrador Retriever', color: 'Yellow'},
       {ownerId:17, name: 'Beethoven', breed: 'St. Bernard'},
       {ownerId:18, name: 'Lassie', breed: 'Collie', color: 'tan and white'},
-      {ownerId:19, name: 'Snoopy', breed: 'beagle', color: 'black and white'}
+      {ownerId:19, name: 'Snoopy', breed: 'beagle', color: 'black and white'},
+      {ownerId:20, name: 'Max', breed: 'Westie'},
+      {ownerId:20, name: 'Gigi', breed: 'Spaniel', color: 'Chocolate'},
+      {ownerId:20, name: 'Mimo', breed: 'Boxer', color: 'Chocolate'},
+      {ownerId:20, name: 'Bepo', breed: 'French Bulldog', color: 'Grey'},
     ]);
 
   });
@@ -158,6 +173,29 @@ describe('Query', function (){
     Dog.query('breed').eq('unknown').where('ownerId').lt(8).exec(function (err, dogs) {
       should.not.exist(err);
       dogs.length.should.eql(2);
+      done();
+    });
+  });
+
+  it('Query on Secondary Global Index with same hashKey', function (done) {
+    var Dog = dynamoose.model('Dog');
+
+    Dog.query('ownerId').eq(20).where('color').beginsWith('Choc').exec(function (err, dogs) {
+      should.not.exist(err);
+      dogs.length.should.eql(2);
+      dogs[0].name.should.eql('Gigi');
+      dogs[1].name.should.eql('Mimo');
+      done();
+    });
+  });
+
+  it('Query on Secondary Global Index with same hashKey and 2nd in index list', function (done) {
+    var Dog = dynamoose.model('Dog');
+
+    Dog.query('ownerId').using('BreedRangeIndex').eq(20).where('breed').beginsWith('Sp').exec(function (err, dogs) {
+      should.not.exist(err);
+      dogs.length.should.eql(1);
+      dogs[0].name.should.eql('Gigi');
       done();
     });
   });


### PR DESCRIPTION
This PR addresses the issue described here
https://github.com/automategreen/dynamoose/issues/86

I read through the comments in the issue, and after looking at the code it looks like I could make a change to support fixing the issue by adding the rangeKey to the check to determine whether to try to use a global secondary index, and also providing the `query.using` functionality to explicitly use a specific index if multiple are configured for the hashkey attribute.

If this solution works for you I will update the Query doc to describe the new feature.