### PR TITLE
Create and Delete GSI sequentially

### DIFF
--- a/lib/Table.js
+++ b/lib/Table.js
@@ -41,7 +41,7 @@ var compareIndexes = function compareIndexes(local, remote) {
         var remoteIndex = _.pick(remoteIndexes[j], 'IndexName', 'KeySchema', 'Projection');
 
         if (!_.isEqual(remoteIndex, localIndex)) {
-          localIndex.ProvisionedThroughput = localIndex.ProvisionedThroughput;
+          localIndex.ProvisionedThroughput = localIndexes[i].ProvisionedThroughput;
           indexes.delete.push(localIndex);
           indexes.create.push(localIndex);
           remoteIndexFound = true;

--- a/lib/Table.js
+++ b/lib/Table.js
@@ -19,8 +19,7 @@ function Table(name, schema, options, base) {
 var compareIndexes = function compareIndexes(local, remote) {
   var indexes = {
     delete: [],
-    create: [],
-    both: []
+    create: []
   };
   var localTableReq = local;
   var remoteTableReq = remote;
@@ -42,7 +41,9 @@ var compareIndexes = function compareIndexes(local, remote) {
         var remoteIndex = _.pick(remoteIndexes[j], 'IndexName', 'KeySchema', 'Projection');
 
         if (!_.isEqual(remoteIndex, localIndex)) {
-          indexes.both.push(localIndexes[i]);
+          localIndex.ProvisionedThroughput = localIndex.ProvisionedThroughput;
+          indexes.delete.push(localIndex);
+          indexes.create.push(localIndex);
           remoteIndexFound = true;
         } else {
           remoteIndexFound = true;
@@ -145,20 +146,21 @@ Table.prototype.init = function (next) {
 
         debug('%s', JSON.stringify(indexes, null, 2));
         if (table.options.update) {
-          debug('checking indexes');
-          for (var deleteIdx in indexes.delete) {
-            table.deleteIndex(indexes.delete[deleteIdx].IndexName);
-          }
-          for (var bothIdx in indexes.both) {
-            /*jshint loopfunc: true */
-            table.deleteIndex(indexes.both[bothIdx].IndexName)
-              .then(function () {
-                table.createIndex(localTableReq.AttributeDefinitions, indexes.both[bothIdx]);
-              });
-          }
-          for (var createIdx in indexes.create) {
-            table.createIndex(localTableReq.AttributeDefinitions, indexes.create[createIdx]);
-          }
+          debug('updating indexes sequentially');
+          var fun = function () {};
+          Q.fcall(fun)
+            .then(function() {
+              return indexes.delete.reduce(function(cur, next) {
+                return cur.then(function() { return table.deleteIndex(next.IndexName); });
+              }, Q.fcall(fun));
+            })
+            .then(function() {
+              return indexes.create.reduce(function(cur, next) {
+                return cur.then(function() { return table.createIndex(localTableReq.AttributeDefinitions, next); });
+              }, Q.fcall(fun));
+            })
+            .catch(function(e) { debug(e); });
+
         } else {
           if (indexes.delete.length > 0 || indexes.create.length > 0) {
             debug('indexes are not synchronized and update flag is set to false');
@@ -181,8 +183,8 @@ Table.prototype.init = function (next) {
               .then(function () {
                 table.initialized = true;
               })
-              .then(function() {
-                if(table.options.waitForActive) {
+              .then(function () {
+                if (table.options.waitForActive) {
                   return table.waitForActive();
                 }
               })

--- a/lib/Table.js
+++ b/lib/Table.js
@@ -147,17 +147,16 @@ Table.prototype.init = function (next) {
         debug('%s', JSON.stringify(indexes, null, 2));
         if (table.options.update) {
           debug('updating indexes sequentially');
-          var fun = function () {};
-          Q.fcall(fun)
+          Q()
             .then(function() {
               return indexes.delete.reduce(function(cur, next) {
                 return cur.then(function() { return table.deleteIndex(next.IndexName); });
-              }, Q.fcall(fun));
+              }, Q());
             })
             .then(function() {
               return indexes.create.reduce(function(cur, next) {
                 return cur.then(function() { return table.createIndex(localTableReq.AttributeDefinitions, next); });
-              }, Q.fcall(fun));
+              }, Q());
             })
             .catch(function(e) { debug(e); });
 


### PR DESCRIPTION
This pr fixes bug with missed required field for dynamodb `ProvisionedThroughput`
Also, dynamodb doesn't support creating and deleting GSI simultaneously.
So added sequential requests.