### PR TITLE
Added support for nested attributes if the type is 'object'

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -37,6 +37,20 @@ function Attribute(schema, name, value) {
   }
 
   this.attributes = {};
+  
+  if (this.type.name === 'object'){
+
+    for (var objSubattrName in value) {
+      if (this.attributes[objSubattrName]) {
+        throw new errors.SchemaError('Duplicate attribute: ' + objSubattrName + ' in ' + this.name);
+      }
+
+      if (value[objSubattrName].type) {
+        this.attributes[objSubattrName] = module.exports.create(schema, objSubattrName, value[objSubattrName]);
+      }
+    }
+
+  }
 
   if (this.type.name === 'map'){
 


### PR DESCRIPTION
I was having an issue with validating complex, nested Attributes, since their sub-attributes were not saved. I have added a case, similar to `map` and `list`, which can be found in the constructor of the Attribute module.

I ran the tests and it did not seem to have any side-effects.