### PR TITLE
#137 - Enhancement/implementing populate

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -467,6 +467,60 @@ Dog.get({ownerId: 4, name: 'Odie'}, function(err, odie) {
 });
 ```
 
+#### Model.populate(options)
+
+Populates paths from an item from the table.
+
+(Only promise mode yet)
+
+```js
+Dog = dynamoose.model('Dog', {
+    id: {
+      type:  Number
+    },
+    name: {
+      type: String
+    },
+    parent: Number
+  })
+
+/*
+Available dogs
+{ id: 1, name: 'Odie'}
+{ id: 2, name: 'Rex', parent: 1 }
+{ id: 3, name: 'Fox', parent: 2 }
+*/
+
+Dog.get(3)
+  .then(function(dog) {
+    return dog.populate({
+      path: 'parent',
+      model: 'Dog',
+      populate: {
+        path: 'parent',
+        model: 'Dog'
+      }
+    });
+  })
+  then(function(dog) {
+    console.log(dog);
+    /*
+    { 
+      id: 3, 
+      name: 'Fox',
+      parent: {
+        id: 2, 
+        name: 'Rex', 
+        parent: {
+          id: 1, 
+          name: 'Odie'
+        }
+      }
+    }
+    */
+  });
+```
+
 #### Model.batchGet(keys, options, callback)
 
 Gets multiple items from the table.

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -7,6 +7,7 @@ var Query = require('./Query');
 var Scan = require('./Scan');
 var errors = require('./errors');
 var reservedKeywords = require('./reserved-keywords');
+var deepSet = require('lodash').set;
 
 //var MAX_BATCH_READ_SIZE   = 100;
 var MAX_BATCH_WRITE_SIZE  = 25;
@@ -77,6 +78,15 @@ Model.compile = function compile (name, schema, options, base) {
       return Model.get(NewModel, key, options, next);
     } catch(err) {
       sendErrorToCallback(err, options, next);
+      return Q.reject(err);
+    }
+  };
+
+  NewModel.populate = function (options, resultObj, fillPath) {
+    try {
+      return Model.populate(options, resultObj, fillPath);
+    } catch(err) {
+      sendErrorToCallback(err, options);
       return Q.reject(err);
     }
   };
@@ -384,11 +394,9 @@ Model.get = function(NewModel, key, options, next) {
       schema.parseDynamo(model, data.Item);
 
       debug('getItem parsed model', model);
-
       deferred.resolve(model);
     });
   }
-
 
   if(newModel$.options.waitForActive) {
     newModel$.table.waitForActive().then(get);
@@ -396,6 +404,40 @@ Model.get = function(NewModel, key, options, next) {
     get();
   }
   return deferred.promise.nodeify(next);
+};
+
+Model.prototype.populate = function (options, resultObj, fillPath) {
+  if (!fillPath) {
+    fillPath = [];
+  }
+  var deferred = Q.defer();
+  var self = this;
+  var Models = this.$__.table.base.models;
+  if (!resultObj) {
+    resultObj = self;
+  }
+  if (!options.path || !options.model) {
+    throw new Error('Invalid parameters provided to the populate method');
+  }
+  try {
+    return Models[options.model]
+      .get(self[options.path])
+      .then(function(target){
+        if (!target) {
+          throw new Error('Invalid reference');
+        } 
+        self[options.path] = target;
+        fillPath = fillPath.concat(options.path);
+        deepSet(resultObj, fillPath, target);
+        if (options.populate) {
+          return self[options.path].populate(options.populate, resultObj, fillPath);
+        } else {
+          return resultObj;
+        }
+      });
+  } catch (err) {
+    deferred.reject(err);
+  }
 };
 
 /* NewModel.update({id: 123},

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -8,6 +8,7 @@ var Scan = require('./Scan');
 var errors = require('./errors');
 var reservedKeywords = require('./reserved-keywords');
 var deepSet = require('lodash').set;
+var _filter = require('lodash').filter;
 
 //var MAX_BATCH_READ_SIZE   = 100;
 var MAX_BATCH_WRITE_SIZE  = 25;
@@ -410,34 +411,34 @@ Model.prototype.populate = function (options, resultObj, fillPath) {
   if (!fillPath) {
     fillPath = [];
   }
-  var deferred = Q.defer();
   var self = this;
-  var Models = this.$__.table.base.models;
   if (!resultObj) {
     resultObj = self;
   }
   if (!options.path || !options.model) {
     throw new Error('Invalid parameters provided to the populate method');
   }
-  try {
-    return Models[options.model]
-      .get(self[options.path])
-      .then(function(target){
-        if (!target) {
-          throw new Error('Invalid reference');
-        } 
-        self[options.path] = target;
-        fillPath = fillPath.concat(options.path);
-        deepSet(resultObj, fillPath, target);
-        if (options.populate) {
-          return self[options.path].populate(options.populate, resultObj, fillPath);
-        } else {
-          return resultObj;
-        }
-      });
-  } catch (err) {
-    deferred.reject(err);
+  var Model = _filter(this.$__.table.base.models, function(model){
+    return model.$__.name === model.$__.options.prefix + options.model || model.$__.name === options.model;
+  }).pop();
+  if (!Model) {
+    throw new Error('The provided model doesn\'t exists');
   }
+  return Model
+    .get(self[options.path])
+    .then(function(target){
+      if (!target) {
+        throw new Error('Invalid reference');
+      } 
+      self[options.path] = target;
+      fillPath = fillPath.concat(options.path);
+      deepSet(resultObj, fillPath, target);
+      if (options.populate) {
+        return self[options.path].populate(options.populate, resultObj, fillPath);
+      } else {
+        return resultObj;
+      }
+    });
 };
 
 /* NewModel.update({id: 123},

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "aws-sdk": "^2.1.0",
     "q": "~1.0.1",
     "hooks": "0.3.2",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "lodash": "*"
   }
 }

--- a/test/Model.js
+++ b/test/Model.js
@@ -12,7 +12,7 @@ dynamoose.local();
 
 var should = require('should');
 
-var Cat, Cat2, Cat3, Cat4, Cat5;
+var Cat, Cat2, Cat3, Cat4, Cat5, Cat6;
 
 describe('Model', function (){
   this.timeout(15000);
@@ -121,6 +121,17 @@ describe('Model', function (){
         saveUnknown: true
       });
 
+    Cat6 = dynamoose.model('Cat6',
+      {
+        id: {
+          type:  Number
+        },
+        name: {
+          type: String
+        },
+        parent: Number
+      }
+    );
     done();
   });
 
@@ -925,6 +936,117 @@ describe('Model', function (){
         });
       });
     });
+  });
+
+  describe('Model.populate', function (){
+    before(function (done) {
+      var kittenWithParents = new Cat6({id: 1, name: 'One'});
+      kittenWithParents.save()
+        .then(function(kitten) {
+          var kittenWithParents = new Cat6({id: 2, name: 'Two', parent: kitten.id});
+          return kittenWithParents.save();
+        })
+        .then(function(kitten) {
+          var kittenWithParents = new Cat6({id: 3, name: 'Three', parent: kitten.id});
+          return kittenWithParents.save();
+        })
+        .then(function(kitten) {
+          var kittenWithParents = new Cat6({id: 4, name: 'Four', parent: kitten.id});
+          return kittenWithParents.save();
+        })
+        .then(function() {
+          var kittenWithParents = new Cat6({id: 5, name: 'Five', parent: 999});
+          return kittenWithParents.save(done);
+        });
+    });
+
+    it('Should populate with one parent', function (done) {
+      Cat6.get(4)
+        .then(function(cat) {
+          return cat.populate({
+            path: 'parent',
+            model: 'test-Cat6'
+          });
+        })
+        .then(function(cat) {
+          should.exist(cat.parent);
+          cat.parent.id.should.eql(3);
+          cat.parent.name.should.eql('Three');
+          done();
+        });
+    });
+
+    it('Should deep populate with mutiple parent', function (done) {
+      Cat6.get(4)
+        .then(function(cat) {
+          return cat.populate({
+            path: 'parent',
+            model: 'test-Cat6',
+            populate: {
+              path: 'parent',
+              model: 'test-Cat6',
+              populate: {
+                path: 'parent',
+                model: 'test-Cat6'  
+              }
+            }
+          });
+        })
+        .then(function(cat) {
+          should.exist(cat.parent);
+          var parent = cat.parent;
+          parent.id.should.eql(3);
+          parent.name.should.eql('Three');
+          parent = parent.parent;
+          parent.id.should.eql(2);
+          parent.name.should.eql('Two');
+          parent = parent.parent;
+          parent.id.should.eql(1);
+          parent.name.should.eql('One');
+          done();
+        });
+    });
+
+    it('Populating without the model definition', function (done) {
+      Cat6.get(4)
+        .then(function(cat) {
+          return cat.populate({
+            path: 'parent'
+          });
+        })
+        .catch(function(err){
+          should.exist(err.message);
+          done();
+        });
+    });
+
+    it('Populating without the path definition', function (done) {
+      Cat6.get(4)
+        .then(function(cat) {
+          return cat.populate({
+            model: 'test-Cat6'
+          });
+        })
+        .catch(function(err){
+          should.exist(err.message);
+          done();
+        });
+    });
+
+    it('Populating with the wrong reference id', function (done) {
+      Cat6.get(5)
+        .then(function(cat) {
+          return cat.populate({
+            path: 'parent',
+            model: 'test-Cat6'
+          });
+        })
+        .catch(function(err){
+          should.exist(err.message);
+          done();
+        });
+    });
+
   });
 
   describe('Model.batchPut', function (){


### PR DESCRIPTION
Issue ref: #137

# Reason
Since this is heavily inspired at Mongoose I think we should also implement the populate methods inspired by them.

This is their ref: [Official docs](http://mongoosejs.com/docs/populate.html)

Also that feature makes coding way faster without the need of implementing consecutive queries to get the full result.

# Proposal
Since I'm a new contributor I don't understand every aspect of this library yet, so I'll purpose small and incremental changes until we have a very similar structure of mongoose's populate method. 

By that I'll list goals here so we can keep track and if anyone else wants to get involved follow up the development.

- [x] Implement the populate method
- [x] Attach the method to the Model definition
- [x] Create tests to test this initial feature
- [ ] Implement the ObjectId + ref options in an attribute
- [ ] Implement a better API, such as `Dog.get(1).populate('father')`
- [ ] Implement a better API, such as `Dog.get(1).populate('father.father')`
- [ ] Improve the documentation

