### PR TITLE
added schema parsing overrides

### DIFF
--- a/docs/_docs/schema.md
+++ b/docs/_docs/schema.md
@@ -143,6 +143,14 @@ Adds a setter function that will be used to transform the value before writing t
 
 Adds a getter function that will be used to transform the value returned from the DB.
 
+**toDynamo**: function
+
+Adds a setter function that will directly set the value to the DB. This skips all type management and parsing normally provided by `options.set`.
+
+**parseDynamo**: function
+
+Adds a getter function that will be used to transform the value directly returned from the DB. This skips all type management and parsing normally provided by `options.get`.
+
 **trim**: boolean
 
 Trim whitespace from string when saving to DB.
@@ -225,5 +233,43 @@ Specifies that attributes not defined in the _schema_ will be saved and retrieve
 ```js
 var schema = new Schema({...}, {
   saveUnknown: true 
+});
+```
+
+**attributeToDynamo**: function
+
+A function that accepts `name, json, model, defaultFormatter`.
+
+This will override attribute formatting for all attributes. Whatever is returned by the function will be sent directly to the DB.
+
+```js
+var schema = new Schema({...}, {
+  attributeToDynamo: function(name, json, model, defaultFormatter) {
+    switch(name) {
+        case 'specialAttribute':
+            return specialFormatter(json);
+        default:
+            return specialFormatter(json);
+    }
+  }
+});
+```
+
+**attributeFromDynamo**: function
+
+A function that accepts `name, json, fallback`.
+
+This will override attribute parsing for all attributes. Whatever is returned by the function will be passed directly to the model instance.
+
+```js
+var schema = new Schema({...}, {
+  attributeFromDynamo: function(name, json, defaultParser) {
+    switch(name) {
+        case 'specialAttribute':
+            return specialParser(json);
+        default:
+            return defaultParser(json);
+    }
+  }
 });
 ```

--- a/docs/_docs/schema.md
+++ b/docs/_docs/schema.md
@@ -147,7 +147,7 @@ Adds a getter function that will be used to transform the value returned from th
 
 Adds a setter function that will directly set the value to the DB. This skips all type management and parsing normally provided by `options.set`.
 
-**parseDynamo**: function
+**fromDynamo**: function
 
 Adds a getter function that will be used to transform the value directly returned from the DB. This skips all type management and parsing normally provided by `options.get`.
 

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -78,7 +78,7 @@ function Attribute(schema, name, value) {
 
     this.required = this.options.required;
     this.set = this.options.set;
-    this.parseDynamoCustom = this.options.parseDynamo;
+    this.parseDynamoCustom = this.options.fromDynamo;
     this.toDynamoCustom = this.options.toDynamo;
     this.get = this.options.get;
 

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -78,6 +78,8 @@ function Attribute(schema, name, value) {
 
     this.required = this.options.required;
     this.set = this.options.set;
+    this.parseDynamoCustom = this.options.parseDynamo;
+    this.toDynamoCustom = this.options.toDynamo;
     this.get = this.options.get;
 
     this.applyValidation(this.options.validate);
@@ -284,6 +286,10 @@ Attribute.prototype.setDefault = function(model) {
 
 Attribute.prototype.toDynamo = function(val, noSet, model) {
 
+  if (this.toDynamoCustom) {
+    return this.toDynamoCustom(val, noSet, model);
+  }
+
   if(val === null || val === undefined || val === '') {
     if(this.required) {
       throw new errors.ValidationError('Required value missing: ' + this.name);
@@ -400,6 +406,10 @@ Attribute.prototype.toDynamo = function(val, noSet, model) {
 
 Attribute.prototype.parseDynamo = function(json) {
 
+  if (this.parseDynamoCustom) {
+    return this.parseDynamoCustom(json);
+  }
+
   function dedynamofy(type, isSet, json, transform, attr) {
     if(!json){
       return;
@@ -502,6 +512,8 @@ Attribute.prototype.parseDynamo = function(json) {
     default:
       throw new errors.SchemaError('Invalid attribute type: ' + this.type);
   }
+
+
 
   if(this.get) {
     val = this.get(val);

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -62,6 +62,8 @@ function Schema(obj, options) {
 
   this.useDocumentTypes = !!this.options.useDocumentTypes;
   this.useNativeBooleans = !!this.options.useNativeBooleans;
+  this.attributeFromDynamo = this.options.attributeFromDynamo;
+  this.attributeToDynamo = this.options.attributeToDynamo;
 
   this.attributes = {};
   this.indexes = {local: {}, global: {}};
@@ -105,7 +107,12 @@ Schema.prototype.toDynamo = function(model) {
     attr = this.attributes[name];
 
     attr.setDefault(model);
-    var dynamoAttr = attr.toDynamo(model[name], undefined, model);
+    var dynamoAttr;
+    if (this.attributeToDynamo) {
+      dynamoAttr = this.attributeToDynamo(name, model[name], model, attr.toDynamo);
+    } else {
+      dynamoAttr = attr.toDynamo(model[name], undefined, model);
+    }
     if(dynamoAttr) {
       dynamoObj[attr.name] = dynamoAttr;
     }
@@ -126,8 +133,13 @@ Schema.prototype.parseDynamo = function(model, dynamoObj) {
     }
 
     if(attr) {
-      var attrVal = attr.parseDynamo(dynamoObj[name]);
-      if(attrVal !== undefined && attrVal !== null){
+      var attrVal;
+      if (this.attributeFromDynamo) {
+        attrVal = this.attributeFromDynamo(name, dynamoObj[name], attr.parseDynamo);
+      } else {
+        attrVal = attr.parseDynamo(dynamoObj[name]);
+      }
+      if (attrVal !== undefined && attrVal !== null) {
         model[name] = attrVal;
       }
     }

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -109,7 +109,7 @@ Schema.prototype.toDynamo = function(model) {
     attr.setDefault(model);
     var dynamoAttr;
     if (this.attributeToDynamo) {
-      dynamoAttr = this.attributeToDynamo(name, model[name], model, attr.toDynamo);
+      dynamoAttr = this.attributeToDynamo(name, model[name], model, attr.toDynamo.bind(attr));
     } else {
       dynamoAttr = attr.toDynamo(model[name], undefined, model);
     }
@@ -135,7 +135,7 @@ Schema.prototype.parseDynamo = function(model, dynamoObj) {
     if(attr) {
       var attrVal;
       if (this.attributeFromDynamo) {
-        attrVal = this.attributeFromDynamo(name, dynamoObj[name], attr.parseDynamo);
+        attrVal = this.attributeFromDynamo(name, dynamoObj[name], attr.parseDynamo.bind(attr));
       } else {
         attrVal = attr.parseDynamo(dynamoObj[name]);
       }

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -592,6 +592,144 @@ describe('Schema tests', function (){
     });
   });
 
+  it('Schema with custom parser', function (done) {
 
+    var schema = new Schema({
+      name: String,
+      owner: String
+    }, {
+      attributeFromDynamo: function(name, value, fallback) {
+        if (name === 'owner') {
+          return 'Cat Lover: ' + value.S;
+        }
+        return fallback(value);
+      }
+    });
+
+    var Cat = dynamoose.model('Cat', schema);
+    var tim = new Cat();
+
+    tim.name = 'tommy';
+    tim.owner = 'bill';
+
+    tim.save(function() {
+      Cat.scan().exec(function(err, models) {
+        if (err) {
+          throw err;
+        }
+        var timSaved = models.pop();
+        timSaved.owner.should.eql('Cat Lover: bill');
+
+        Cat.$__.table.delete(function () {
+          delete dynamoose.models.Cat;
+          done();
+        });
+      });
+    });
+  });
+
+  it('Schema with custom formatter', function (done) {
+
+    var schema = new Schema({
+      name: String,
+      owner: String
+    }, {
+      attributeToDynamo: function(name, value, model, fallback) {
+        if (name === 'owner') {
+          return {S: 'Cat Lover: ' + value};
+        }
+        return fallback(value);
+      }
+    });
+
+    var Cat = dynamoose.model('Cat', schema);
+    var tim = new Cat();
+
+    tim.name = 'tommy';
+    tim.owner = 'bill';
+
+    tim.save(function() {
+      Cat.scan().exec(function(err, models) {
+        if (err) {
+          throw err;
+        }
+        var timSaved = models.pop();
+        timSaved.owner.should.eql('Cat Lover: bill');
+
+        Cat.$__.table.delete(function () {
+          delete dynamoose.models.Cat;
+          done();
+        });
+      });
+    });
+  });
+
+  it('Attribute with custom parser', function (done) {
+
+    var schema = new Schema({
+      name: String,
+      owner: {
+        type: String,
+        fromDynamo: function(json) {
+          return 'Cat Lover: ' + json.S;
+        }
+      }
+    });
+
+    var Cat = dynamoose.model('Cat', schema);
+    var tim = new Cat();
+
+    tim.name = 'tommy';
+    tim.owner = 'bill';
+
+    tim.save(function() {
+      Cat.scan().exec(function(err, models) {
+        if (err) {
+          throw err;
+        }
+        var timSaved = models.pop();
+        timSaved.owner.should.eql('Cat Lover: bill');
+
+        Cat.$__.table.delete(function () {
+          delete dynamoose.models.Cat;
+          done();
+        });
+      });
+    });
+  });
+
+  it('Schema with custom formatter', function (done) {
+
+    var schema = new Schema({
+      name: String,
+      owner: {
+        type: String,
+        toDynamo: function(value) {
+          return {S: 'Cat Lover: ' + value};
+        }
+      }
+    });
+
+    var Cat = dynamoose.model('Cat', schema);
+    var tim = new Cat();
+
+    tim.name = 'tommy';
+    tim.owner = 'bill';
+
+    tim.save(function() {
+      Cat.scan().exec(function(err, models) {
+        if (err) {
+          throw err;
+        }
+        var timSaved = models.pop();
+        timSaved.owner.should.eql('Cat Lover: bill');
+
+        Cat.$__.table.delete(function () {
+          delete dynamoose.models.Cat;
+          done();
+        });
+      });
+    });
+  });
 
 });


### PR DESCRIPTION
Added per field dynamo parsing overrides in addition to schema-wide parsing overrides.

The per field overrides are a convenience, but the schema-wide overrides can help users manage unknown properties.

From the Docs:

```js
var schema = new Schema({...}, {
  attributeFromDynamo: function(name, json, defaultParser) {
    switch(name) {
        case 'specialAttribute':
            return specialParser(json);
        default:
            return defaultParser(json);
    }
  }
});
```
--- or ---

```js
var schema = new Schema({...}, {
  attributeFromDynamo: function(name, json, defaultParser) {
    if (appearsToBeASpecialType(json)) {
      return specialParser(json);
    }
    return defaultParser(json);
  }
});
```