### PR TITLE
Found typo in Static Methods docs

### DIFF
--- a/docs/_docs/schema.md
+++ b/docs/_docs/schema.md
@@ -281,7 +281,7 @@ You can add custom methods to your Schema
 #### Static Methods
 
 Can be accessed from the compiled Schema, similar to how `scan()` and `query()` are called.
-`this` will refer to the commpiled schema within the definition of the function.
+`this` will refer to the compiled schema within the definition of the function.
 
 ```js
 


### PR DESCRIPTION
s/commpiled/compiled

No idea why there is a diff for line 326...