### PR TITLE
Cast model values to their respectable schema types

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -60,6 +60,7 @@ Model.compile = function compile (name, schema, options, base) {
   function NewModel (obj) {
     Model.call(this, obj);
     applyVirtuals(this, schema);
+    schema.parseDynamo(this, obj);
   }
 
   util.inherits(NewModel, Model);

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -60,7 +60,7 @@ Model.compile = function compile (name, schema, options, base) {
   function NewModel (obj) {
     Model.call(this, obj);
     applyVirtuals(this, schema);
-    schema.parseDynamo(this, obj);
+    schema.parseDynamo(this, schema.toDynamo(this));
   }
 
   util.inherits(NewModel, Model);

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -60,7 +60,6 @@ Model.compile = function compile (name, schema, options, base) {
   function NewModel (obj) {
     Model.call(this, obj);
     applyVirtuals(this, schema);
-    schema.parseDynamo(this, schema.toDynamo(this));
   }
 
   util.inherits(NewModel, Model);
@@ -276,6 +275,8 @@ Model.prototype.put = function(options, next) {
       TableName: this.$__.name,
       Item: schema.toDynamo(this)
     };
+
+    schema.parseDynamo(this, item.Item);
 
     if(!options.overwrite) {
       if (!reservedKeywords.isReservedKeyword(schema.hashKey.name)) {


### PR DESCRIPTION
This adds support for proper typecasting of the models. Currently, if `dynamoose.Model` receives an `Object`, it does not try to validate and parse it, which, at times, can cause model to not strictly adhere to types. Take a look at this example:
```js
import dynamoose, {Schema} from 'dynamoose';

dynamoose.AWS.config.update({
  region: 'us-east-1'
});
// Local Dynamo instance
dynamoose.local('http://localhost:4569');

const bugSchema = new Schema({
  id: {
    type: Number,
    required: true
  },
  message: {
    type: String,
    required: true
  }
});

const bugModel = dynamoose.model('Bug', bugSchema);

bugModel.create({
  // id is a String.
  id: '1234',
  message: 'This is a bug',
}).then((model) => {
  // Logs: string
  console.log(typeof model.id);
});
```

In the above example dynamoose would not do typecasting, that it is able to do, even before sending data to DynamoDB. This causes type problems, because we expect that `model.id` to be a `Number`, not `String`. While in JS-land that's not a big deal, it might be in others.

While I'm not overly familiar with the codebase, I do think that this patch should be enough to make dynamoose work 👌 and properly typecast.