### PR TITLE
Add proper support for 'CONTAINS' filter for lists on scans

### DIFF
--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -98,11 +98,14 @@ Scan.prototype.exec = function (next) {
           ComparisonOperator: filter.comparison
         };
 
+        var isContains = filter.comparison === 'CONTAINS' || filter.comparison === 'NOT_CONTAINS';
+        var isListContains = isContains && filterAttr.type.name === 'list';
+
         if(filter.values) {
           for (var i = 0; i < filter.values.length; i++) {
             var val = filter.values[i];
             scanReq.ScanFilter[name].AttributeValueList.push(
-              filterAttr.toDynamo(val, true)
+              isListContains ? filterAttr.attributes[0].toDynamo(val, true) : filterAttr.toDynamo(val, true)
             );
           }
         }


### PR DESCRIPTION
[DynamoDB fully supports running 'contain' filters on Lists](http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Condition.html), but currently trying to perform a 'contains' filter on a list in a scan with Dynamoose improperly gives the error "'Values must be array in a `list`", due to it being converted to the Dynamo value with the parent list Attribute instead of the list sub-attribute. 

Eg. `Model.scan({listAttribute: {contains: 'value'}}).exec()` fails when it should succeed by returning all results that have a 'value' entry in the listAttribute List.