### PR TITLE
Fix usage of next callback without checking for existence

### DIFF
--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -287,7 +287,10 @@ Scan.prototype.exec = function (next) {
 
   if(Model$.options.waitForActive) {
     return Model$.table.waitForActive().then(scan).catch(function (err) {
-      next(err);
+      if (next) {
+        next(err);
+      }
+      return Q.reject(err);
     });
   }
 


### PR DESCRIPTION
At the top of the `exec()` function, it checks for the existence of the `next` callback, and returns a promise if it does not exist:
```
  if (this.validationError) {
    if (next) {
      next(this.validationError);
    }
    return Q.reject(this.validationError);
  }
```
However at the bottom, if the waitForActive option is set, it does not perform this check and simply calls `next()`, which causes the function to throw an error when waitForActive is set and `next` is not provided. This commit fixes this issue, so it will always check and return a promise if `next` is not set.