### PR TITLE
Bugfix - Cast raw scans to models too

### DIFF
--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -52,13 +52,19 @@ Scan.prototype.exec = function (next) {
 
   var scanReq = { };
 
-  function toModel (item) {
-    var model = new Model();
+  function toModel (item, skipParsing) {
+    var model;
+
+    if (!skipParsing) {
+      model = new Model();
+      schema.parseDynamo(model, item);
+    } else {
+      model = new Model(item);
+    }
+
     model.$__.isNew = false;
-    schema.parseDynamo(model, item);
 
     debug('scan parsed model', model);
-
     return model;
   }
 
@@ -72,7 +78,9 @@ Scan.prototype.exec = function (next) {
           if (!data) {
             return deferred.resolve([]);
           }
-          return deferred.resolve(data.Items.map(toModel));
+          return deferred.resolve(data.Items.map(function (item) {
+            return toModel(item, true);
+          }));
         }
       });
 

--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -52,6 +52,16 @@ Scan.prototype.exec = function (next) {
 
   var scanReq = { };
 
+  function toModel (item) {
+    var model = new Model();
+    model.$__.isNew = false;
+    schema.parseDynamo(model, item);
+
+    debug('scan parsed model', model);
+
+    return model;
+  }
+
     function scanByRawFilter() {
       var deferred = Q.defer();
       var dbClient = Model.$__.base.documentClient();
@@ -62,7 +72,7 @@ Scan.prototype.exec = function (next) {
           if (!data) {
             return deferred.resolve([]);
           }
-          return deferred.resolve(data.Items);
+          return deferred.resolve(data.Items.map(toModel));
         }
       });
 
@@ -181,16 +191,6 @@ Scan.prototype.exec = function (next) {
 
         if(!Object.keys(data).length) {
           return deferred.resolve();
-        }
-
-        function toModel (item) {
-          var model = new Model();
-          model.$__.isNew = false;
-          schema.parseDynamo(model, item);
-
-          debug('scan parsed model', model);
-
-          return model;
         }
 
         try {

--- a/test/Scan.js
+++ b/test/Scan.js
@@ -706,6 +706,27 @@ describe('Scan', function (){
       });
   });
 
+  it('Raw AWS filter should return model instances', function (done) {
+    var Dog = dynamoose.model('Dog');
+    var filter = {
+      FilterExpression: 'details.timeWakeUp = :wakeUp',
+      ExpressionAttributeValues: {
+        ':wakeUp': '8am'
+      }
+    };
+
+    Dog.scan(filter, { useRawAwsFilter: true }).exec()
+      .then(function(dogs) {
+        dogs[0].should.be.instanceof(Dog);
+        done();
+      })
+      .catch(function(err) {
+        should.not.exist(err);
+        console.error(err);
+        done();
+      });
+  });
+
   it('Scan parallel', function (done) {
     var Dog = dynamoose.model('Dog');
 


### PR DESCRIPTION
This is a simple fix to fix a case such as:

```js
import Model from '../../models/models';

var filters = {
  FilterExpression: 'attr = :attr',
  ExpressionAttributeValues: {
    ':attr': attr
  }
};

return Model
  .scan(filters)
  .exec()
  .then((results) => {
    return results[0]; // Plain Object
  });
```

Since we are still performing a scan on a known table of a known model, it makes sense to also cast all of the objects to that model.