### PR TITLE
Add validation for callback before call it

### DIFF
--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -287,7 +287,9 @@ Scan.prototype.exec = function (next) {
 
   if(Model$.options.waitForActive) {
     return Model$.table.waitForActive().then(scan).catch(function (err) {
-      next(err);
+      if (next) {
+        next(err);
+      }
     });
   }
 


### PR DESCRIPTION
## What does this PR do?
- Add a validation to see if callback exists before call it, because when you call ```scan.get()``` without a callback and the server is not retrieving data, it crashes.

## Where should the reviewer start?
:checkered_flag:
lib/Scan.js

## Screenshots
```TypeError: next is not a function```
```node_modules/dynamoose/lib/Scan.js:290:7```