### PR TITLE
Fixed type definition of SchemaOptions

### DIFF
--- a/dynamoose.d.ts
+++ b/dynamoose.d.ts
@@ -60,8 +60,8 @@ declare module "dynamoose" {
     saveUnknown?: boolean;
 
     // @todo more strong type definition
-    attributeToDynamo: (name: string, json: any, model: any, defaultFormatter: any) => any;
-    attributeFromDynamo: (name: string, json: any, fallback: any) => any;
+    attributeToDynamo?: (name: string, json: any, model: any, defaultFormatter: any) => any;
+    attributeFromDynamo?: (name: string, json: any, fallback: any) => any;
   }
 
   export interface SchemaAttributes {


### PR DESCRIPTION
Made `attributeFromDynamo` and `attributeToDynamo` optional in type definition of `SchemaOptions`. In current state api consumer would need to implement these operations in order to set scalar schema options.