### PR TITLE
Fix typo in schema.md

### DIFF
--- a/docs/_docs/schema.md
+++ b/docs/_docs/schema.md
@@ -141,7 +141,7 @@ function(value, model) {
 }
 ```
 
-If it is a RegExp, it is compared using `RegExp.text(value)`.
+If it is a RegExp, it is compared using `RegExp.test(value)`.
 
 If it is a value, it is compared with `===`.
 


### PR DESCRIPTION
Regular expressions are matched with 'test' not 'text'.

Confusing for javascript nubs like myself.