### PR TITLE
Bug fix: In Model.put() / Model.save(), the returned promise is not rejected on error

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -257,7 +257,6 @@ Model.prototype.put = function(options, next) {
       }
       deferred.resolve(model);
     });
-    return deferred.promise.nodeify(next);
   }
 
   try {
@@ -295,14 +294,14 @@ Model.prototype.put = function(options, next) {
     var model$ = this.$__;
 
     if(model$.options.waitForActive) {
-      return model$.table.waitForActive().then(putItem).catch(deferred.reject);
+      model$.table.waitForActive().then(putItem).catch(deferred.reject);
+    } else {
+      putItem();
     }
-
-    return putItem();
   } catch(err) {
     deferred.reject(err);
-    return deferred.promise.nodeify(next);
   }
+  return deferred.promise.nodeify(next);
 };
 
 Model.prototype.save = Model.prototype.put;


### PR DESCRIPTION
For example, if doing a conditional save that fails, the returned promise object is resolved instead of being rejected.
This happens because the following code returns the wrong promise:
if(model$.options.waitForActive) { return model$.table.waitForActive().then(putItem).catch(deferred.reject); }