### PR TITLE
Enable http keep alive functionality

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 var Schema = require('./Schema');
 var Model = require('./Model');
+var https = require('https');
 
 var debug = require('debug')('dynamoose');
 
@@ -78,10 +79,25 @@ Dynamoose.prototype.ddb = function () {
   }
   if(this.endpointURL) {
     debug('Setting DynamoDB to %s', this.endpointURL);
-    this.dynamoDB = new this.AWS.DynamoDB({ endpoint: new this.AWS.Endpoint(this.endpointURL) });
+    this.dynamoDB = new this.AWS.DynamoDB({
+      endpoint: new this.AWS.Endpoint(this.endpointURL),
+      httpOptions: {
+        agent: new https.Agent({
+          rejectUnauthorized: true,
+          keepAlive: true
+        })
+      }
+    });
   } else {
     debug('Getting default DynamoDB');
-    this.dynamoDB = new this.AWS.DynamoDB();
+    this.dynamoDB = new this.AWS.DynamoDB({
+      httpOptions: {
+        agent: new https.Agent({
+          rejectUnauthorized: true,
+          keepAlive: true
+        })
+      }
+    });
   }
   return this.dynamoDB;
 };


### PR DESCRIPTION
In our use case (AWS lambda functions) this improves the time it takes to make a typical DynamoDB request from 100-200ms to 10-20ms. It's possible this should be a configuration setting or something instead of always enabled, but I wanted to submit this first and get feedback on whether that is necessary and how it should be done.