### PR TITLE
AWS dynamodb expects milliseconds, not seconds for TTL/Expires.

### DIFF
--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -93,10 +93,10 @@ function Schema(obj, options) {
       type: Number,
       default: defaultExpires,
       set: function(v) {
-        return Math.floor(v.getTime() / 1000);
+        return Math.floor(v.getTime());
       },
       get: function (v) {
-        return new Date(v * 1000);
+        return new Date(v);
       }
     };
     this.expires = expires;


### PR DESCRIPTION
Should be the same format as the timestamps in the preceding lines.