### PR TITLE
Enable unit test code coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "coverage": "grunt coverage"
   },
   "keywords": [
     "dynamodb",
@@ -41,7 +42,7 @@
     "grunt": "^1.0.1",
     "grunt-contrib-jshint": "^1.1.0",
     "grunt-mocha-test": "^0.13.2",
-    "mocha": "^3.4.2",
+    "mocha": "^2.5.3",
     "should": "^11.2.1",
     "travis-cov": "^0.2.5"
   },


### PR DESCRIPTION
Hi Brandon, I was bitten by #197 and noticed that the accepted fix in #200 did not include a test that could have caught the problem.

I tried to generate the unit test code coverage report for this module with `grunt coverage` but received a `"html-cov" reporter not found` error.

It appears mocha dropped support for `html-cov` reporting in v3.0.0.

Given this module does not appear to require any of the features of Mocha v3, the quickest way to generate a coverage report was to downgrade Mocha to the most recent v2.x version.

With the small change in this PR it is now possible to use `npm run coverage` (or `yarn coverage`) to generate full code coverage reports.

![](https://screenshots.firefoxusercontent.com/images/e1e568ed-eff5-473e-ac74-23043324c88b.png)

Whilst "downgrading" Mocha may feel like a step backwards, the ability to generate a code coverage report provides a big step forwards in terms of confidence-building in this useful module.

If there's interest, I could take a look at modernising the test tooling to use something like `nyc`, which provides more useful statistics around branch coverage.

Cheers,
Lovell
