### PR TITLE
Bugfix - Provide model when converting keys .toDynamo.

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -851,11 +851,11 @@ Model.prototype.delete = function(options, next) {
   };
 
   try {
-    getDelete.Key[hashKeyName] = schema.hashKey.toDynamo(this[hashKeyName]);
+    getDelete.Key[hashKeyName] = schema.hashKey.toDynamo(this[hashKeyName], undefined, this);
 
     if(schema.rangeKey) {
       var rangeKeyName = schema.rangeKey.name;
-      getDelete.Key[rangeKeyName] = schema.rangeKey.toDynamo(this[rangeKeyName]);
+      getDelete.Key[rangeKeyName] = schema.rangeKey.toDynamo(this[rangeKeyName], undefined, this);
     }
   } catch (err) {
     deferred.reject(err);

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -363,11 +363,11 @@ Model.get = function(NewModel, key, options, next) {
     Key: {}
   };
 
-  getReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+  getReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName], undefined, key);
 
   if(schema.rangeKey) {
     var rangeKeyName = schema.rangeKey.name;
-    getReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+    getReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName], undefined, key);
   }
 
   if(options.attributes) {
@@ -527,11 +527,11 @@ Model.update = function(NewModel, key, update, options, next) {
   };
   processCondition(updateReq, options, NewModel.$__.schema);
 
-  updateReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+  updateReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName], undefined, key);
 
   if(schema.rangeKey) {
     var rangeKeyName = schema.rangeKey.name;
-    updateReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+    updateReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]), undefined, key;
   }
 
   // determine the set of operations to be executed
@@ -1014,11 +1014,11 @@ Model.batchGet = function(NewModel, keys, options, next) {
 
   getReq.Keys = keys.map(function (key) {
     var ret = {};
-    ret[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+    ret[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName], undefined, key);
 
     if(schema.rangeKey) {
       var rangeKeyName = schema.rangeKey.name;
-      ret[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName]);
+      ret[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName], undefined, key);
     }
     return ret;
   });
@@ -1218,10 +1218,10 @@ Model.batchDelete = function(NewModel, keys, options, next) {
 
   var batchRequests = toBatchChunks(newModel$.name, keys, MAX_BATCH_WRITE_SIZE, function(key) {
     var key_element = {};
-    key_element[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]);
+    key_element[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]), undefined, key;
 
     if(schema.rangeKey) {
-      key_element[schema.rangeKey.name] = schema.rangeKey.toDynamo(key[schema.rangeKey.name]);
+      key_element[schema.rangeKey.name] = schema.rangeKey.toDynamo(key[schema.rangeKey.name], undefined, key);
     }
 
     return {


### PR DESCRIPTION
This allows schema to run validation and defaults. Take the following schema for example:
```js
new Schema({
  id: {
    type: String,
    index: {
      global: true
    },
    required: true,
    default: model => `${model.properties.ownerType}_${model.properties.ownerId}`,
    validate: (value, model) => value === `${model.properties.ownerType}_${model.properties.ownerId}`
  },
  properties: {
    type: 'map',
    map: {
      ownerType: {
        type: String,
        validate: value => ownerTypes.includes(value),
        required: true
      },
      ownerId: {
        type: Number,
        validate: value => typeof value === 'number',
        required: true
      },
      organizationId: {
        type: Number,
        validate: value => typeof value === 'number',
        required: true
      }
    }
  }
});
```

Now suppose I wanted to delete a model of that schema by doing the following:
```js
AModel.delete();
```

There would be a JS exception raised due to `model` being `undefined` in `validate` method, because `schema.rangeKey.toDynamo` and/or `schema.hashKey.toDynamo` were not given the actual model as a context.

This PR fixes this particular edge case. However, I noticed that there are quite a few occurrences where `.toDynamo` is being called without providing a model - should those callsites also provide a model?