### PR TITLE
Fix range key on queries

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -45,7 +45,7 @@ function Query (Model, query, options) {
       rangeKeyVal = rangeKeyVal[rangeKeyComp];
       this.query.rangeKey = {
         name: rangeKeyName,
-        value: rangeKeyVal,
+        values: [rangeKeyVal],
         comparison: rangeKeyComp
       };
     }
@@ -159,7 +159,7 @@ Query.prototype.exec = function (next) {
         AttributeValueList: [],
         ComparisonOperator: filter.comparison.toUpperCase()
       };
-      
+
       var isContains = filter.comparison === 'CONTAINS' || filter.comparison === 'NOT_CONTAINS';
       var isListContains = isContains && filterAttr.type.name === 'list';
 


### PR DESCRIPTION
Currently range keys don't work on Queries when constructed all at once via the constructor because it uses the `value` key, while the `exec` function looks for the `values` key. This is the simplest possible commit that allows range keys to work via the Query constructor, though I'm not sure if it's the best solution, please let me know if there's a better way of fixing this issue.