### PR TITLE
Fix to allow unknown types to be populated as native dynamo types

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -16,8 +16,11 @@ function Attribute(schema, name, value) {
   this.schema = schema;
 
   this.name = name;
-
-  this.setType(value);
+  if (this.schema.options.saveUnknown) {
+    this.setTypeFromRawValue(value);
+  } else {
+    this.setType(value);
+  }
 
   if(!schema.useDocumentTypes) {
     if(this.type.name === 'map') {
@@ -61,10 +64,10 @@ function Attribute(schema, name, value) {
     if (value === undefined && value[0] === undefined){
       throw new errors.SchemaError('No object given for attribute:' + this.name );
     }
-
-    if (value.length > 1){
-      throw new errors.SchemaError('Only one object can be defined as a list type in ' + this.name );
-    }
+    // stang: Don't know what this guard is for - had to remove because when parsing unknown attributes, this is legal?
+    // if (value.length > 1){
+    //   throw new errors.SchemaError('Only one object can be defined as a list type in ' + this.name );
+    // }
 
 
     for (var i = 0; i < value.length; i++) {
@@ -145,6 +148,45 @@ Attribute.prototype.types = {
   }
 };
 
+Attribute.prototype.setTypeFromRawValue = function(value) {
+  //no type defined - assume this is not a type definition and we must grab type directly from value
+  if(!value) {
+    throw new errors.SchemaError('Invalid attribute value: ' + value);
+  }
+
+  var type;
+  var typeVal = value;
+  if (value.type){
+    typeVal = value.type;
+  }
+
+  if (util.isArray(typeVal)){
+    type = 'List';
+  } else if ( (util.isArray(typeVal) && typeVal.length === 1) || typeof typeVal === 'function') {
+    this.isSet = util.isArray(typeVal);
+    var regexFuncName = /^Function ([^(]+)\(/i;
+    var found = typeVal.toString().match(regexFuncName);
+    type = found[1];
+  } else if (typeof typeVal === 'object'){
+    type = 'Map';
+  } else {
+    type = typeof typeVal;
+  }
+
+  if(!type) {
+    throw new errors.SchemaError('Invalid attribute type: ' + type);
+  }
+
+  type = type.toLowerCase();
+
+  this.type = this.types[type];
+
+  if(!this.type) {
+    throw new errors.SchemaError('Invalid attribute type: ' + type);
+  }
+
+};
+
 Attribute.prototype.setType = function(value) {
   if(!value) {
     throw new errors.SchemaError('Invalid attribute value: ' + value);
@@ -157,7 +199,7 @@ Attribute.prototype.setType = function(value) {
   }
 
   if (util.isArray(typeVal) && typeVal.length === 1 && typeof typeVal[0] === 'object'){
-     type = 'List';
+    type = 'List';
   } else if ( (util.isArray(typeVal) && typeVal.length === 1) || typeof typeVal === 'function') {
     this.isSet = util.isArray(typeVal);
     var regexFuncName = /^Function ([^(]+)\(/i;

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -139,7 +139,7 @@ Schema.prototype.toDynamo = function(model) {
     attr = this.attributes[name];
 
     if(!attr & this.options.saveUnknown) {
-      attr = Attribute.create(this, name, typeof model[name]);
+      attr = Attribute.create(this, name, model[name]);
       this.attributes[name] = attr;
     }
   }

--- a/test/Model.js
+++ b/test/Model.js
@@ -12,7 +12,7 @@ dynamoose.local();
 
 var should = require('should');
 
-var Cat, Cat2, Cat3, Cat4, Cat5, Cat6, Cat7, Cat8, CatWithOwner, Owner, ExpiringCat, CatWithGeneratedID;
+var Cat, Cat1, Cat2, Cat3, Cat4, Cat5, Cat6, Cat7, Cat8, CatWithOwner, Owner, ExpiringCat, CatWithGeneratedID;
 
 var ONE_YEAR = 365*24*60*60; // 1 years in seconds
 var NINE_YEARS = 9*ONE_YEAR; // 9 years in seconds
@@ -52,6 +52,29 @@ describe('Model', function (){
       }
     },
     {useDocumentTypes: true});
+
+    // Create a model with unnamed attributes
+    Cat1 = dynamoose.model('Cat1',
+      {
+        id: {
+          type:  Number,
+          validate: function (v) { return v > 0; },
+          default: 888
+        },
+        name: {
+          type: String,
+          required: true,
+          default: 'Mittens'
+        },
+        owner: String
+        // children: {
+        //   type: Object
+        // }
+      },
+      {
+        useDocumentTypes: true,
+        saveUnknown: true
+      });
 
     // Create a model with a range key
     Cat2 = dynamoose.model('Cat2',
@@ -379,6 +402,78 @@ describe('Model', function (){
         owner: { S: 'Someone' },
         unnamedInt: { N: '1' },
         unnamedString: { S: 'unnamed' },
+      });
+
+    kitten.save(done);
+
+  });
+
+  it('Create complex model with unnamed attributes', function (done) {
+
+
+    this.timeout(12000);
+
+
+    Cat1.should.have.property('$__');
+
+    Cat1.$__.name.should.eql('test-Cat1');
+    Cat1.$__.options.should.have.property('saveUnknown', true);
+
+    var schema = Cat1.$__.schema;
+
+    should.exist(schema);
+
+    schema.attributes.id.type.name.should.eql('number');
+    should(schema.attributes.id.isSet).not.be.ok;
+    should.exist(schema.attributes.id.default);
+    should.exist(schema.attributes.id.validator);
+    should(schema.attributes.id.required).not.be.ok;
+
+    schema.attributes.name.type.name.should.eql('string');
+    schema.attributes.name.isSet.should.not.be.ok;
+    should.exist(schema.attributes.name.default);
+    should.not.exist(schema.attributes.name.validator);
+    should(schema.attributes.name.required).be.ok;
+
+    schema.hashKey.should.equal(schema.attributes.id); // should be same object
+    should.not.exist(schema.rangeKey);
+
+    var kitten = new Cat1(
+      {
+        id: 2,
+        name: 'Fluffy',
+        owner: 'Someone',
+        children: {
+          "mittens" : {
+            name : "mittens",
+            age: 1
+          },
+          "puddles" : {
+            name : "puddles",
+            age: 2
+          }
+        }
+        ,characteristics: ['cute', 'fuzzy']
+      }
+    );
+
+    kitten.id.should.eql(2);
+    kitten.name.should.eql('Fluffy');
+
+    var dynamoObj = schema.toDynamo(kitten);
+
+    dynamoObj.should.eql(
+      {
+        id: {N: '2'},
+        name: {S: 'Fluffy'},
+        owner: {S: 'Someone'},
+        children: {
+          M: {
+            "mittens": {M: {"name": {S: "mittens"}, "age": {N: '1'}}},
+            "puddles": {M: {"name": {S: "puddles"}, "age": {N: '2'}}}
+          }
+        }
+        ,characteristics: {L: [{S: 'cute'}, {S: 'fuzzy'}]}
       });
 
     kitten.save(done);

--- a/test/Model.js
+++ b/test/Model.js
@@ -452,8 +452,8 @@ describe('Model', function (){
             name : "puddles",
             age: 2
           }
-        }
-        ,characteristics: ['cute', 'fuzzy']
+        },
+        characteristics: ['cute', 'fuzzy']
       }
     );
 
@@ -472,8 +472,8 @@ describe('Model', function (){
             "mittens": {M: {"name": {S: "mittens"}, "age": {N: '1'}}},
             "puddles": {M: {"name": {S: "puddles"}, "age": {N: '2'}}}
           }
-        }
-        ,characteristics: {L: [{S: 'cute'}, {S: 'fuzzy'}]}
+        },
+        characteristics: {L: [{S: 'cute'}, {S: 'fuzzy'}]}
       });
 
     kitten.save(done);


### PR DESCRIPTION
Fix to allow unknown types to be populated as native dynamo types when useDocumentTypes=true

I separated out the basic `Attribute.setType` from `Attribute.setTypeFromRawValue` instead of conditionals inside `Attribute.setType` to clearly differentiate when what should be called and the purpose of each method.  I've also commented out a piece of code in `Attribute.js` since it would break the toDynamo on a List (unknown Attribute).  I'm not sure what the guard is there for (possible for defined schema so there are no heterogenous lists?).  I will leave it at your discretion to modify.

I've also added a Test for this particular case.  All tests still pass.