### PR TITLE
Remove JSON.stringify for model in Debug message

### DIFF
--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -166,7 +166,7 @@ Schema.prototype.toDynamo = function(model) {
     }
   }
 
-  debug('toDynamo: %s', JSON.stringify(dynamoObj) );
+  debug('toDynamo: %s', dynamoObj );
   return dynamoObj;
 };
 
@@ -194,7 +194,7 @@ Schema.prototype.parseDynamo = function(model, dynamoObj) {
     }
   }
 
-  debug('parseDynamo: %s',JSON.stringify(model));
+  debug('parseDynamo: %s', model);
 
   return dynamoObj;
 


### PR DESCRIPTION
This is causing 'Converting circular structure to JSON' error.

If the model is complex enough then this will cause the above error so removed JSON.stringify