### PR TITLE
Adding Query.all to documentation

### DIFF
--- a/docs/_docs/query.md
+++ b/docs/_docs/query.md
@@ -25,6 +25,14 @@ Dog.query({breed: {eq: 'Beagle'} }, function (err, dogs) {
 
 Executes the query against the table or index.
 
+### query.all([delay[, max]])
+
+Recursively query as long as lastKey exists. This function will also return a property called `timesScanned` indicating how many queries were completed.
+
+`delay` is the time (in seconds) between recursive queries. Default: 1sec
+
+`max` is the maximum number of recursive queries. Default: 0 - unlimited
+
 ### query.where(rangeKey)
 
 Set the range key of the table or index to query.


### PR DESCRIPTION
This PR adds `Query.all` to the documentation from PR #223.