### PR TITLE
Changing Query.all() timesScanned to timesQueried

### DIFF
--- a/docs/_docs/query.md
+++ b/docs/_docs/query.md
@@ -25,6 +25,14 @@ Dog.query({breed: {eq: 'Beagle'} }, function (err, dogs) {
 
 Executes the query against the table or index.
 
+### query.all([delay[, max]])
+
+Recursively query as long as lastKey exists. This function will also return a property called `timesScanned` indicating how many queries were completed.
+
+`delay` is the time (in seconds) between recursive queries. Default: 1sec
+
+`max` is the maximum number of recursive queries. Default: 0 - unlimited
+
 ### query.where(rangeKey)
 
 Set the range key of the table or index to query.

--- a/docs/_docs/query.md
+++ b/docs/_docs/query.md
@@ -27,7 +27,7 @@ Executes the query against the table or index.
 
 ### query.all([delay[, max]])
 
-Recursively query as long as lastKey exists. This function will also return a property called `timesScanned` indicating how many queries were completed.
+Recursively query as long as lastKey exists. This function will also return a property called `timesQueried` indicating how many queries were completed.
 
 `delay` is the time (in seconds) between recursive queries. Default: 1sec
 

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -218,7 +218,7 @@ Query.prototype.exec = function (next) {
       options.all = {'delay': 0, 'max': 1};
     }
 
-    var models = {}, totalCount = 0, scannedCount = 0, timesScanned = 0, lastKey;
+    var models = {}, totalCount = 0, scannedCount = 0, timesQueried = 0, lastKey;
     queryOne();
 
     function queryOne() {
@@ -269,9 +269,9 @@ Query.prototype.exec = function (next) {
           }
           totalCount += data.Count;
           scannedCount += data.ScannedCount;
-          timesScanned++;
+          timesQueried++;
 
-          if ((options.all.max === 0 || timesScanned < options.all.max) && lastKey) {
+          if ((options.all.max === 0 || timesQueried < options.all.max) && lastKey) {
             // query.all need to query again
             queryReq.ExclusiveStartKey = lastKey;
             setTimeout(queryOne, options.all.delay * 1000);
@@ -279,7 +279,7 @@ Query.prototype.exec = function (next) {
             models.lastKey = lastKey;
             models.count = totalCount;
             models.scannedCount = scannedCount;
-            models.timesScanned = timesScanned;
+            models.timesQueried = timesQueried;
             deferred.resolve(models);
           }
         } catch (err) {

--- a/test/Query.js
+++ b/test/Query.js
@@ -370,7 +370,7 @@ describe('Query', function (){
     Dog.query('ownerId').eq(20).limit(1).all(1, 3).exec()
     .then(function (dogs) {
       dogs.length.should.eql(3);
-      dogs.timesScanned.should.eql(3);
+      dogs.timesQueried.should.eql(3);
       done();
     })
     .catch(done);


### PR DESCRIPTION
Changing Query.all() timesScanned to timesQueried, since we are querying instead of scanning.

**This PR is based on PR #285, so that PR should probably be approved first**