### PR TITLE
added clarification for schema get function

### DIFF
--- a/docs/_docs/schema.md
+++ b/docs/_docs/schema.md
@@ -151,7 +151,7 @@ Adds a setter function that will be used to transform the value before writing t
 
 **get**: function
 
-Adds a getter function that will be used to transform the value returned from the DB.
+Adds a getter function that will be used to transform the value returned from the DB, fired only if there is a value returned from the DB.
 
 **toDynamo**: function
 


### PR DESCRIPTION
Small change to documentation to clarify the get function is only fired should there be an item returned from the database, indicating that you cannot use this method to insert blank strings in fields that are not returned as the method would never be fired.