### PR TITLE
batchPut() not working with async/await keywords

### DIFF
--- a/test/Model.js
+++ b/test/Model.js
@@ -1385,6 +1385,30 @@ describe('Model', function (){
         done();
       });
     });
+    
+    it('Use async await to put', function (done) {
+      var cats = [];
+
+      for (var i=0 ; i<100 ; ++i) {
+        cats.push(new Cats.Cat({id: 100+i, name: 'Tom_'+i}));
+      }
+      var asyncPut = function(){
+        done();
+      };
+      var es6code = 
+        'asyncPut = function () {'+
+          'var result = await Cats.Cat.batchPut(cats) '+
+          'should.exist(result)'+
+          'result.length.should.eql(cats.length)'+
+        '}'+
+        'asyncPut()'; 
+      eval(es6code);
+      asyncPut().catch(function(err){
+        should.not.exist(err);
+        done();
+      });
+    });
+
 
     it('Update items', function (done) {
       var cats = [];


### PR DESCRIPTION
Hey I noticed the `batchPut` method doesn't work with async/await syntax:

I wrote a test for it but the linter wasn't sure how to configure the test runner to run this one in a higher version of node.
I get this back when using:
```js
let results = await Model.batchPut(models)
console.log(results)
//"{"Responses":{},"UnprocessedItems":{}}"

```