### PR TITLE
Normalise Scan response shape when using "RawAWSFilter"

### DIFF
--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -65,7 +65,7 @@ Scan.prototype.exec = function (next) {
     function scanByRawFilter() {
       var deferred = Q.defer();
       var dbClient = Model.$__.base.documentClient();
-      var AWSSet = dbClient.createSet([1, 2, 3]).constructor;
+      var DynamoDBSet = dbClient.createSet([1, 2, 3]).constructor;
 
       dbClient.scan(scanReq, function(err, data) {
         if (err) {
@@ -78,7 +78,7 @@ Scan.prototype.exec = function (next) {
             var model;
 
             Object.keys(item).forEach(function (prop) {
-              if (item.hasOwnProperty(prop) && item[prop] instanceof AWSSet) {
+              if (item[prop] instanceof DynamoDBSet) {
                 item[prop] = item[prop].values;
               }
             });

--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -65,6 +65,8 @@ Scan.prototype.exec = function (next) {
     function scanByRawFilter() {
       var deferred = Q.defer();
       var dbClient = Model.$__.base.documentClient();
+      var AWSSet = dbClient.createSet([1, 2, 3]).constructor;
+
       dbClient.scan(scanReq, function(err, data) {
         if (err) {
           return deferred.reject(err);
@@ -73,7 +75,15 @@ Scan.prototype.exec = function (next) {
             return deferred.resolve([]);
           }
           return deferred.resolve(data.Items.map(function (item) {
-            var model = new Model(item);
+            var model;
+
+            Object.keys(item).forEach(function (prop) {
+              if (item.hasOwnProperty(prop) && item[prop] instanceof AWSSet) {
+                item[prop] = item[prop].values;
+              }
+            });
+
+            model = new Model(item);
             model.$__.isNew = false;
             debug('scan parsed model', model);
             return model;


### PR DESCRIPTION
## Problem
When using a raw AWS filter to Scan the returned Item shape is not consistent with a regular Scan.

Instead of:
```
NewModel {
    name: 'Snoopy',
    details: { timeWakeUp: '8am', timeSleep: '8pm' },
    ownerId: 19,
    color:  ['black', 'white'],
    cartoon: 'true',
    breed: 'Beagle'
}
```
We get:
```
NewModel {
    name: 'Snoopy',
    details: { timeWakeUp: '8am', timeSleep: '8pm' },
    ownerId: 19,
    color: Set { values: ['black', 'white'], type: 'String' },
    cartoon: 'true',
    breed: 'Beagle'
}
```
This is happening because `AWS.DynamoDB.DocumentClient` creates `Set` instances for attributes of type StringSet etc. These aren't native instances of `Set` but rather a custom AWS Class which isn't exposed.

## Solution
When mapping over the returned objects within `Scan.js` I iterate over each items properties and check for such instances to convert them to regular array instances.