### PR TITLE
Fix saveUnknown throwing errors when value where falsy

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -150,10 +150,6 @@ Attribute.prototype.types = {
 
 Attribute.prototype.setTypeFromRawValue = function(value) {
   //no type defined - assume this is not a type definition and we must grab type directly from value
-  if(!value) {
-    throw new errors.SchemaError('Invalid attribute value: ' + value);
-  }
-
   var type;
   var typeVal = value;
   if (value.type){

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -143,9 +143,12 @@ Schema.prototype.toDynamo = function(model) {
     if(!model.hasOwnProperty(name)){
       continue;
     }
+    if (model[name] === undefined || model[name] === null || Number.isNaN(model[name])) {
+      debug('toDynamo: skipping attribute: %s because its definition or value is null, undefined, or NaN', name);
+      continue;
+    }
     attr = this.attributes[name];
-
-    if(!attr & this.options.saveUnknown) {
+    if(!attr && this.options.saveUnknown) {
       attr = Attribute.create(this, name, model[name]);
       this.attributes[name] = attr;
     }

--- a/test/Model.js
+++ b/test/Model.js
@@ -182,7 +182,17 @@ describe('Model', function (){
         name: 'Fluffy',
         owner: 'Someone',
         unnamedInt: 1,
+        unnamedInt0: 0,
+        unnamedBooleanFalse: false,
+        unnamedBooleanTrue: true,
         unnamedString: 'unnamed',
+
+        // Attributes with empty values. DynamoDB won't store empty values
+        // so the return value of toDynamo() should exclude these attributes.
+        unnamedUndefined: undefined,
+        unnamedNull: null,
+        unnamedEmptyString: '',
+        unnamedNumberNaN: NaN,
       }
     );
 
@@ -197,6 +207,9 @@ describe('Model', function (){
         name: { S: 'Fluffy' },
         owner: { S: 'Someone' },
         unnamedInt: { N: '1' },
+        unnamedInt0: { N: '0' },
+        unnamedBooleanFalse: { S: 'false' },
+        unnamedBooleanTrue: { S: 'true' },
         unnamedString: { S: 'unnamed' },
       });
 

--- a/test/Model.js
+++ b/test/Model.js
@@ -112,7 +112,7 @@ describe('Model', function (){
     Cats.Cat2.should.have.property('name');
     // Older node doesn't support Function.name changes
     if (Object.getOwnPropertyDescriptor(Function, 'name').configurable) {
-      Cats.Cat2.name.should.eql('Model-test-Cat2');
+      Cats.Cat2.name.should.eql('Model-test-Cat2-db');
     }
 
     Cats.Cat2.should.have.property('$__');
@@ -149,7 +149,7 @@ describe('Model', function (){
     Cats.Cat5.should.have.property('name');
     // Older node doesn't support Function.name changes
     if (Object.getOwnPropertyDescriptor(Function, 'name').configurable) {
-      Cats.Cat5.name.should.eql('Model-test-Cat5');
+      Cats.Cat5.name.should.eql('Model-test-Cat5-db');
     }
 
     Cats.Cat5.should.have.property('$__');
@@ -212,7 +212,7 @@ describe('Model', function (){
     Cats.Cat1.should.have.property('name');
     // Older node doesn't support Function.name changes
     if (Object.getOwnPropertyDescriptor(Function, 'name').configurable) {
-      Cats.Cat1.name.should.eql('Model-test-Cat1');
+      Cats.Cat1.name.should.eql('Model-test-Cat1-db');
     }
 
     Cats.Cat1.should.have.property('$__');


### PR DESCRIPTION
When a model has saveUnknown=true and trying to save the model with an unknown attribute with `0` or `false` values was causing `Attribute.setTypeFromRawValue` to throw a `SchemaError`.

I remove the value check from `setTypeFromRawValue`, which I assume was unnecessarily copied from `setType`. This allows `0` and `false` to be correctly converted to dynamo types.

Attributes with the other falsy values like are `null`, `undefined`, or  'NaN' are now excluded because it was causing `new Attribute` to throw `TypeError` at https://github.com/automategreen/dynamoose/blob/35deac2aaaa418f01b37d9bf8427626a22d142d7/lib/Attribute.js#L12

Also fix the NewModel name test to include missing suffix.