### PR TITLE
Adding Node.js version 10 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "10"
   - "9"
   - "8"
   - "7"


### PR DESCRIPTION
This PR adds Node.js version 10 to the Travis.CI test matrix.