### PR TITLE
Allow saving falsey values with saveUnknown

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -150,7 +150,7 @@ Attribute.prototype.types = {
 
 Attribute.prototype.setTypeFromRawValue = function(value) {
   //no type defined - assume this is not a type definition and we must grab type directly from value
-  if(!value) {
+  if(value === undefined || value === null || isNaN(value)) {
     throw new errors.SchemaError('Invalid attribute value: ' + value);
   }
 

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -150,7 +150,7 @@ Attribute.prototype.types = {
 
 Attribute.prototype.setTypeFromRawValue = function(value) {
   //no type defined - assume this is not a type definition and we must grab type directly from value
-  if(value === undefined || value === null || isNaN(value)) {
+  if(!value && (value === undefined || value === null || isNaN(value))) {
     throw new errors.SchemaError('Invalid attribute value: ' + value);
   }
 

--- a/test/Model.js
+++ b/test/Model.js
@@ -528,6 +528,15 @@ describe('Model', function (){
     });
   });
 
+  it('Static Creates new item with unknown fields', function (done) {
+    Cats.Cat1.create({ id: 666, name: 'Garfield', bool: false }, function (err, garfield) {
+      should.not.exist(err);
+      should.exist(garfield);
+      garfield.bool.should.eql(false);
+      done();
+    });
+  });
+
   it('Static Creates new item with range key', function (done) {
     Cats.Cat2.create({ownerId: 666, name: 'Garfield'}, function (err, garfield) {
       should.not.exist(err);


### PR DESCRIPTION
Addresses #360 

Values of `false`, `''`, and `0` should all be saved without error.